### PR TITLE
consensus: enforce `block.timestamp` > `parent.timestamp`

### DIFF
--- a/consensus/taiko/consensus.go
+++ b/consensus/taiko/consensus.go
@@ -127,7 +127,7 @@ func (t *Taiko) verifyHeader(chain consensus.ChainHeaderReader, header, parent *
 	}
 
 	// Timestamp should later than or equal to parent (when many L2 blocks included in one L1 block)
-	if header.Time < parent.Time {
+	if header.Time <= parent.Time {
 		return ErrOlderBlockTime
 	}
 

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -425,18 +425,9 @@ func (api *ConsensusAPI) NewPayloadV1(params beacon.ExecutableDataV1) (beacon.Pa
 		log.Error("Ignoring pre-merge parent block", "number", params.Number, "hash", params.BlockHash, "td", ptd, "ttd", ttd)
 		return beacon.INVALID_TERMINAL_BLOCK, nil
 	}
-	// CHANGE(taiko): a block that has the same timestamp as its parents is
-	// allowed in Taiko protocol.
-	if api.eth.BlockChain().Config().Taiko {
-		if block.Time() < parent.Time() {
-			log.Warn("Invalid timestamp", "parent", block.Time(), "block", block.Time())
-			return api.invalid(errors.New("invalid timestamp"), parent.Header()), nil
-		}
-	} else {
-		if block.Time() <= parent.Time() {
-			log.Warn("Invalid timestamp", "parent", block.Time(), "block", block.Time())
-			return api.invalid(errors.New("invalid timestamp"), parent.Header()), nil
-		}
+	if block.Time() <= parent.Time() {
+		log.Warn("Invalid timestamp", "parent", block.Time(), "block", block.Time())
+		return api.invalid(errors.New("invalid timestamp"), parent.Header()), nil
 	}
 	// Another cornercase: if the node is in snap sync mode, but the CL client
 	// tries to make it import a block. That should be denied as pushing something

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -981,17 +981,10 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 	// to parent+1 if the mutation is allowed.
 	timestamp := genParams.timestamp
 	if parent.Time() >= timestamp {
-		// CHANGE(taiko): block.timestamp == parent.timestamp is allowed in Taiko protocol.
-		if !w.chainConfig.Taiko {
-			if genParams.forceTime {
-				return nil, fmt.Errorf("invalid timestamp, parent %d given %d", parent.Time(), timestamp)
-			}
-			timestamp = parent.Time() + 1
-		} else {
-			if parent.Time() > timestamp {
-				return nil, fmt.Errorf("invalid timestamp, parent %d given %d", parent.Time(), timestamp)
-			}
+		if genParams.forceTime {
+			return nil, fmt.Errorf("invalid timestamp, parent %d given %d", parent.Time(), timestamp)
 		}
+		timestamp = parent.Time() + 1
 	}
 	// Construct the sealing block header, set the extra field if it's allowed
 	num := parent.Number()


### PR DESCRIPTION
ref: https://github.com/taikochain/taiko-mono/pull/188