### PR TITLE
refactor(faucet ui): Update faucet.html to make it more straightforward

### DIFF
--- a/cmd/faucet/faucet.html
+++ b/cmd/faucet/faucet.html
@@ -51,7 +51,7 @@
 					<div class="col-lg-8 col-lg-offset-2">
 						<h3>How to request Ether?</h3>
 						<ol>
-							<li> <a href="https://twitter.com/intent/tweet?text=Requesting%20faucet%20funds%20into%200x0000000000000000000000000000000000000000%20on%20the%20%23{{.Network}}%20%23Ethereum%20test%20network." target="_about:blank">Make a tweet</a> with your own address (to repleace the <code>0x0</code> address in the template). </li>
+							<li> <a href="https://twitter.com/intent/tweet?text=I%27m%20requesting%20some%20Ether%20from%20%23Taiko%27s%20{{.Network}}%20faucet.%20My%20address%20is%200x0000000000000000000000000000000000000000.%20Learn%20more%20at%20https%3A%2F%2Ftaiko.xyz%2Fdocs%2Fintro." target="_about:blank">Make a tweet</a> with your own address (to repleace the <code>0x0</code> address in the template). </li>
 
 							<li style="padding-bottom: 20px;">Copy the URL of the tweet, paste it below, then click <i>Give me Ether</i>.</li>
 						</ol>
@@ -93,7 +93,6 @@
 						</div>
 					</div>
 				</div>
-
 				<div class="row">
 					<div class="col-lg-8 col-lg-offset-2">
 						<h3>Try our Bridge</h3>

--- a/cmd/faucet/faucet.html
+++ b/cmd/faucet/faucet.html
@@ -96,7 +96,7 @@
 				<div class="row">
 					<div class="col-lg-8 col-lg-offset-2">
 						<h3>Try our Bridge</h3>
-						<p>When you receive Ether, please try <a href="https://bridge.a1.taiko.xyz">Taiko's cross-chain Bridge</a> to transfer Ether between our private Ethereum testnet and the Taiko A1 testnet.</p>
+						<p>When you receive Ether, please try <a href="https://bridge.a1.taiko.xyz">Taiko's Bridge</a> to transfer Ether and ERC20 tokens between Ethereum and Taiko.</p>
 					</div>
 				</div>
 			</div>

--- a/cmd/faucet/faucet.html
+++ b/cmd/faucet/faucet.html
@@ -98,7 +98,6 @@
 					<div class="col-lg-8 col-lg-offset-2">
 						<h3>Try our Bridge</h3>
 						<p>When you receive Ether, please try <a href="https://bridge.a1.taiko.xyz">Taiko's cross-chain Bridge</a> to transfer Ether between our private Ethereum testnet and the Taiko A1 testnet.</p>
-
 					</div>
 				</div>
 			</div>

--- a/cmd/faucet/faucet.html
+++ b/cmd/faucet/faucet.html
@@ -5,7 +5,7 @@
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 
-		<title>{{.Network}}: Authenticated Faucet</title>
+		<title>{{.Network}} Faucet</title>
 
 		<link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" />
 		<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" />
@@ -43,13 +43,28 @@
 			<div class="container">
 				<div class="row" style="margin-bottom: 16px;">
 					<div class="col-lg-12">
-						<h1 style="text-align: center;"><i class="fa fa-bath" aria-hidden="true"></i> {{.Network}} Authenticated Faucet</h1>
+						<h1 style="text-align: center; color:#fc0fc0">{{.Network}} <i class="fa fa-tint" aria-hidden="true"></i> Faucet</h1>
 					</div>
 				</div>
+
+				<div class="row">
+					<div class="col-lg-8 col-lg-offset-2">
+						<h3>How to request Ether?</h3>
+						<ol>
+							<li> <a href="https://twitter.com/intent/tweet?text=Requesting%20faucet%20funds%20into%200x0000000000000000000000000000000000000000%20on%20the%20%23{{.Network}}%20%23Ethereum%20test%20network." target="_about:blank">Make a tweet</a> with your own address (to repleace the <code>0x0</code> address in the template). </li>
+
+							<li style="padding-bottom: 20px;">Copy the URL of the tweet, paste it below, then click <i>Give me Ether</i>.</li>
+						</ol>
+
+					</div>
+				</div>
+
+
+
 				<div class="row">
 					<div class="col-lg-8 col-lg-offset-2">
 						<div class="input-group">
-							<input id="url" name="url" type="text" class="form-control" placeholder="Social network URL containing your Ethereum address..."/>
+							<input id="url" name="url" type="text" class="form-control" placeholder="The URL of your tweet"/>
 							<span class="input-group-btn">
 								<button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Give me Ether	<i class="fa fa-caret-down" aria-hidden="true"></i></button>
 				        <ul class="dropdown-menu dropdown-menu-right">{{range $idx, $amount := .Amounts}}
@@ -60,8 +75,9 @@
 						<div class="g-recaptcha" data-sitekey="{{.Recaptcha}}" data-callback="submit" data-size="invisible"></div>{{end}}
 					</div>
 				</div>
-				<div class="row" style="margin-top: 32px;">
-						<div class="col-lg-6 col-lg-offset-3">
+
+					<div class="row" style="margin-top: 32px;">
+						<div class="col-lg-8 col-lg-offset-2">
 						<div class="panel panel-small panel-default">
 							<div class="panel-body" style="padding: 0; overflow: auto; max-height: 300px;">
 								<table id="requests" class="table table-condensed" style="margin: 0;"></table>
@@ -77,24 +93,12 @@
 						</div>
 					</div>
 				</div>
-				<div class="row" style="margin-top: 32px;">
-					<div class="col-lg-12">
-						<h3>How does this work?</h3>
-						<p>This Ether faucet is running on the {{.Network}} network. To prevent malicious actors from exhausting all available funds or accumulating enough Ether to mount long running spam attacks, requests are tied to common 3rd party social network accounts. Anyone having a Twitter or Facebook account may request funds within the permitted limits.</p>
-						<dl class="dl-horizontal">
-							<dt style="width: auto; margin-left: 40px;"><i class="fa fa-twitter" aria-hidden="true" style="font-size: 36px;"></i></dt>
-							<dd style="margin-left: 88px; margin-bottom: 10px;"></i> To request funds via Twitter, make a <a href="https://twitter.com/intent/tweet?text=Requesting%20faucet%20funds%20into%200x0000000000000000000000000000000000000000%20on%20the%20%23{{.Network}}%20%23Ethereum%20test%20network." target="_about:blank">tweet</a> with your Ethereum address pasted into the contents (surrounding text doesn't matter).<br/>Copy-paste the <a href="https://support.twitter.com/articles/80586" target="_about:blank">tweets URL</a> into the above input box and fire away!</dd>
 
-							<dt style="width: auto; margin-left: 40px;"><i class="fa fa-facebook" aria-hidden="true" style="font-size: 36px;"></i></dt>
-							<dd style="margin-left: 88px; margin-bottom: 10px;"></i> To request funds via Facebook, publish a new <strong>public</strong> post with your Ethereum address embedded into the content (surrounding text doesn't matter).<br/>Copy-paste the <a href="https://www.facebook.com/help/community/question/?id=282662498552845" target="_about:blank">posts URL</a> into the above input box and fire away!</dd>
+				<div class="row">
+					<div class="col-lg-8 col-lg-offset-2">
+						<h3>Try our Bridge</h3>
+						<p>When you receive Ether, please try <a href="https://bridge.a1.taiko.xyz">Taiko's cross-chain Bridge</a> to transfer Ether between our private Ethereum testnet and the Taiko A1 testnet.</p>
 
-							{{if .NoAuth}}
-								<dt class="text-danger" style="width: auto; margin-left: 40px;"><i class="fa fa-unlock-alt" aria-hidden="true" style="font-size: 36px;"></i></dt>
-								<dd class="text-danger" style="margin-left: 88px; margin-bottom: 10px;"></i> To request funds <strong>without authentication</strong>, simply copy-paste your Ethereum address into the above input box (surrounding text doesn't matter) and fire away.<br/>This mode is susceptible to Byzantine attacks. Only use for debugging or private networks!</dd>
-							{{end}}
-						</dl>
-						<p>You can track the current pending requests below the input field to see how much you have to wait until your turn comes.</p>
-						{{if .Recaptcha}}<em>The faucet is running invisible reCaptcha protection against bots.</em>{{end}}
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
### Previous
<img width="1590" alt="Screenshot 2022-12-14 at 13 53 41" src="https://user-images.githubusercontent.com/1710087/207517685-87eb6a4c-4a0c-4ce9-b4ad-57187896555e.png">

### Afterward

<img width="1596" alt="Screenshot 2022-12-14 at 13 52 44" src="https://user-images.githubusercontent.com/1710087/207517736-cfbd2742-1b85-42d2-9330-928639c49c36.png">


The name of the two testnets should be:

- "Ethereum (Taiko's Private L1)"
- "Taiko (A1 Testnet)"

So on the UI, the titles are "Ethereum (Taiko's Private L1) Faucet" and "Taiko (A1 Testnet) Faucet"