### PR TITLE
fix(types): catch geth withdrawals root hash up to latest protocol changes

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -467,7 +467,7 @@ func HeaderParentHashFromRLP(header []byte) common.Hash {
 }
 
 // CHANGE(taiko): calc withdrawals root by hashing deposits with keccak256.
-// Golang equivilant to this solidity function:
+// Golang equivalent to this solidity function:
 // function hashDeposits(TaikoData.EthDeposit[] memory deposits) internal pure returns (bytes32) {
 // bytes memory buffer;
 //

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -479,7 +479,7 @@ func HeaderParentHashFromRLP(header []byte) common.Hash {
 //	 }
 func CalcWithdrawalsRootTaiko(withdrawals []*Withdrawal) common.Hash {
 	// only process withdrawals/deposits of 8 minimum
-	if len(withdrawals) < 8 {
+	if len(withdrawals) == 0 {
 		return EmptyWithdrawalsHash
 	}
 

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -18,6 +18,7 @@
 package types
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -465,20 +466,34 @@ func HeaderParentHashFromRLP(header []byte) common.Hash {
 	return common.BytesToHash(parentHash)
 }
 
-// CHANGE(taiko): calc withdrawals root by hashing deposits with keccak256
+// CHANGE(taiko): calc withdrawals root by hashing deposits with keccak256.
+// Golang equivilant to this solidity function:
+// function hashDeposits(TaikoData.EthDeposit[] memory deposits) internal pure returns (bytes32) {
+// bytes memory buffer;
+//
+//	 for (uint256 i = 0; i < deposits.length; i++) {
+//		  buffer = abi.encodePacked(buffer, deposits[i].recipient, deposits[i].amount);
+//	 }
+//
+//	 return keccak256(buffer);
+//	 }
 func CalcWithdrawalsRootTaiko(withdrawals []*Withdrawal) common.Hash {
-	if len(withdrawals) == 0 {
+	// only process withdrawals/deposits of 8 minimum
+	if len(withdrawals) < 8 {
 		return EmptyWithdrawalsHash
 	}
-	var result []byte
-	for _, withdrawal := range withdrawals {
-		amountBytes := new(big.Int).SetUint64(withdrawal.Amount).Bytes()
-		paddedAmountBytes := make([]byte, 12)
-		copy(paddedAmountBytes[12-len(amountBytes):], amountBytes)
 
-		result = append(result, withdrawal.Address.Bytes()...)
-		result = append(result, paddedAmountBytes...)
+	var b []byte
+
+	for _, withdrawal := range withdrawals {
+		// uint96 solidity type needs us to make 12 length byte slice and put
+		// the uint64 into the last 8 bytes. solidity is also bigendian by
+		// default so we need to be specific.
+		amountBytes := make([]byte, 12)
+		binary.BigEndian.PutUint64(amountBytes[4:], withdrawal.Amount)
+
+		b = bytes.Join([][]byte{b, withdrawal.Address.Bytes(), amountBytes}, nil)
 	}
 
-	return crypto.Keccak256Hash(result)
+	return crypto.Keccak256Hash(b)
 }

--- a/core/types/block_test.go
+++ b/core/types/block_test.go
@@ -357,16 +357,6 @@ func Test_CalcWithdrawalsRootTaiko(t *testing.T) {
 			EmptyWithdrawalsHash,
 		},
 		{
-			"lessThanLength8",
-			[]*Withdrawal{
-				{
-					Address: common.HexToAddress("0xa9bcF99f5eb19277f48b71F9b14f5960AEA58a89"),
-					Amount:  1000000000000000000,
-				},
-			},
-			EmptyWithdrawalsHash,
-		},
-		{
 			"withWithdrawals",
 			[]*Withdrawal{
 				{

--- a/core/types/block_test.go
+++ b/core/types/block_test.go
@@ -344,7 +344,7 @@ func TestRlpDecodeParentHash(t *testing.T) {
 	}
 }
 
-// c hange(TAIKO): test
+// change(TAIKO): test
 func Test_CalcWithdrawalsRootTaiko(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -357,18 +357,52 @@ func Test_CalcWithdrawalsRootTaiko(t *testing.T) {
 			EmptyWithdrawalsHash,
 		},
 		{
+			"lessThanLength8",
+			[]*Withdrawal{
+				{
+					Address: common.HexToAddress("0xa9bcF99f5eb19277f48b71F9b14f5960AEA58a89"),
+					Amount:  1000000000000000000,
+				},
+			},
+			EmptyWithdrawalsHash,
+		},
+		{
 			"withWithdrawals",
 			[]*Withdrawal{
 				{
-					Address: common.HexToAddress("0x388C818CA8B9251b393131C08a736A67ccB19297"),
-					Amount:  100000000,
+					Address: common.HexToAddress("0xa9bcF99f5eb19277f48b71F9b14f5960AEA58a89"),
+					Amount:  1000000000000000000,
 				},
 				{
-					Address: common.HexToAddress("0xeEE27662c2B8EBa3CD936A23F039F3189633e4C8"),
-					Amount:  184938493,
+					Address: common.HexToAddress("0x200708D76eB1B69761c23821809d53F65049939e"),
+					Amount:  2000000000000000000,
+				},
+				{
+					Address: common.HexToAddress("0x300C9b60E19634e12FC6D68B7FEa7bFB26c2E419"),
+					Amount:  3000000000000000000,
+				},
+				{
+					Address: common.HexToAddress("0x400147C0Eb43D8D71b2B03037bB7B31f8f78EF5F"),
+					Amount:  4000000000000000000,
+				},
+				{
+					Address: common.HexToAddress("0x50081b12838240B1bA02b3177153Bca678a86078"),
+					Amount:  5000000000000000000,
+				},
+				{
+					Address: common.HexToAddress("0x430c9b60e19634e12FC6d68B7fEa7bFB26c2e419"),
+					Amount:  6000000000000000000,
+				},
+				{
+					Address: common.HexToAddress("0x520147C0eB43d8D71b2b03037bB7b31f8F78EF5f"),
+					Amount:  7000000000000000000,
+				},
+				{
+					Address: common.HexToAddress("0x61081B12838240B1Ba02b3177153BcA678a86078"),
+					Amount:  8000000000000000000,
 				},
 			},
-			common.HexToHash("0xc3f16b87d5d286399c3d4daa4e7e3ae75840d66d0560863a2bdb4eb1bfaff229"),
+			common.HexToHash("0x8117066d69ff650d78f0d7383a10cc802c2b8c0eedd932d70994252e2438c636"),
 		},
 	}
 


### PR DESCRIPTION
paired taiko-mono PR: https://github.com/taikoxyz/taiko-mono/pull/13781

This PR cleans up the implementation to be more specific about being big endian rather than manipulating byte slice, and adds an identical-to-solidity-test more complicated test case to ensure hash is identical.  