### PR TITLE
fix(types): fix empty `withdrawalsRoot` hash value

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -468,7 +468,7 @@ func HeaderParentHashFromRLP(header []byte) common.Hash {
 // CHANGE(taiko): calc withdrawals root by hashing deposits with keccak256
 func CalcWithdrawalsRootTaiko(withdrawals []*Withdrawal) common.Hash {
 	if len(withdrawals) == 0 {
-		return EmptyWithdrawalsHash
+		return EmptyCodeHash // a known keccak256 hash of the empty payload bytes.
 	}
 	var result []byte
 	for _, withdrawal := range withdrawals {

--- a/core/types/block_test.go
+++ b/core/types/block_test.go
@@ -354,7 +354,7 @@ func Test_CalcWithdrawalsRootTaiko(t *testing.T) {
 		{
 			"empty",
 			nil,
-			EmptyWithdrawalsHash,
+			EmptyCodeHash,
 		},
 		{
 			"withWithdrawals",


### PR DESCRIPTION
The empty `withdrawalsRoot` hash value should not be an empty MPT root hash, but a keccak256 hash of an empty payload bytes. 