### PR TITLE
feat(params): params mapping for looking up a chain config by chain ID

### DIFF
--- a/params/taiko_config.go
+++ b/params/taiko_config.go
@@ -19,6 +19,29 @@ var (
 	JolnirNetworkID          = big.NewInt(167007)
 )
 
+var networkIDToChainConfig = map[*big.Int]*ChainConfig{
+	TaikoInternalNetworkID:     TaikoChainConfig,
+	TaikoInternalL3NetworkID:   TaikoChainConfig,
+	SnaefellsjokullNetworkID:   TaikoChainConfig,
+	AskjaNetworkID:             TaikoChainConfig,
+	GrimsvotnNetworkID:         TaikoChainConfig,
+	EldfellNetworkID:           TaikoChainConfig,
+	JolnirNetworkID:            TaikoChainConfig,
+	MainnetChainConfig.ChainID: MainnetChainConfig,
+	SepoliaChainConfig.ChainID: SepoliaChainConfig,
+	GoerliChainConfig.ChainID:  GoerliChainConfig,
+	TestChainConfig.ChainID:    TestChainConfig,
+	NonActivatedConfig.ChainID: NonActivatedConfig,
+}
+
+func NetworkIDToChainConfigOrDefault(networkID *big.Int) *ChainConfig {
+	if config, ok := networkIDToChainConfig[networkID]; ok {
+		return config
+	}
+
+	return AllEthashProtocolChanges
+}
+
 var TaikoChainConfig = &ChainConfig{
 	ChainID:                       TaikoInternalNetworkID, // Use Internal Devnet network ID by default.
 	HomesteadBlock:                common.Big0,

--- a/params/taiko_config_test.go
+++ b/params/taiko_config_test.go
@@ -1,0 +1,78 @@
+package params
+
+import (
+	"math/big"
+	"testing"
+)
+
+func TestNetworkIDToChainConfigOrDefault(t *testing.T) {
+	tests := []struct {
+		name            string
+		networkID       *big.Int
+		wantChainConfig *ChainConfig
+	}{
+		{
+			"taikoInternal",
+			TaikoInternalNetworkID,
+			TaikoChainConfig,
+		},
+		{
+			"taikoInternalL3NetworkId",
+			TaikoInternalL3NetworkID,
+			TaikoChainConfig,
+		},
+		{
+			"snaefoll",
+			SnaefellsjokullNetworkID,
+			TaikoChainConfig,
+		},
+		{
+			"askja",
+			AskjaNetworkID,
+			TaikoChainConfig,
+		},
+		{
+			"grimsvotn",
+			GrimsvotnNetworkID,
+			TaikoChainConfig,
+		},
+		{
+			"eldfellNetworkID",
+			EldfellNetworkID,
+			TaikoChainConfig,
+		},
+		{
+			"jolnirNetworkID",
+			JolnirNetworkID,
+			TaikoChainConfig,
+		},
+		{
+			"mainnet",
+			MainnetChainConfig.ChainID,
+			MainnetChainConfig,
+		},
+		{
+			"sepolia",
+			SepoliaChainConfig.ChainID,
+			SepoliaChainConfig,
+		},
+		{
+			"goerli",
+			GoerliChainConfig.ChainID,
+			GoerliChainConfig,
+		},
+		{
+			"doesntExist",
+			big.NewInt(89390218390),
+			AllEthashProtocolChanges,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if config := NetworkIDToChainConfigOrDefault(tt.networkID); config != tt.wantChainConfig {
+				t.Fatalf("expected %v, got %v", config, tt.wantChainConfig)
+			}
+		})
+	}
+}


### PR DESCRIPTION
To calculate a predictable base fee usign `misc.CalcBaseFee`, a params config is needed. However, it is impossible to do this dynamically without this mapping - it requires you to know which chain you are on. It would be simpler to just look it up via this mapping, knowing the chainID you are trying to send a transaction on only.