### PR TITLE
fix(taiko_worker): fix a `maxBytesPerTxList` check issue

### DIFF
--- a/miner/taiko_worker.go
+++ b/miner/taiko_worker.go
@@ -254,6 +254,7 @@ func (w *worker) commitL2Transactions(
 		env.txs = append(env.txs, firstTransaction)
 	}
 
+loop:
 	for {
 		// If we don't have enough gas for any further transactions then we're done.
 		if env.gasPool.Gas() < params.TxGas {
@@ -319,24 +320,23 @@ func (w *worker) commitL2Transactions(
 			env.tcount++
 			txs.Shift()
 
+			// Encode and compress the txList, if the byte length is > maxBytesPerTxList, remove the latest tx.
+			b, err := encodeAndComporeessTxList(env.txs)
+			if err != nil {
+				log.Trace("Failed to rlp encode and compress the pending transaction %s: %w", tx.Hash(), err)
+				txs.Pop()
+				continue
+			}
+			if len(b) > int(maxBytesPerTxList) {
+				lastTransaction = env.txs[env.tcount-1]
+				env.txs = env.txs[0 : env.tcount-1]
+				break loop
+			}
 		default:
 			// Transaction is regarded as invalid, drop all consecutive transactions from
 			// the same sender because of `nonce-too-high` clause.
 			log.Trace("Transaction failed, account skipped", "hash", ltx.Hash, "err", err)
 			txs.Pop()
-		}
-
-		// Encode and compress the txList, if the byte length is > maxBytesPerTxList, remove the latest tx and break.
-		b, err := encodeAndComporeessTxList(env.txs)
-		if err != nil {
-			log.Trace("Failed to rlp encode and compress the pending transaction %s: %w", tx.Hash(), err)
-			txs.Pop()
-			continue
-		}
-		if len(b) > int(maxBytesPerTxList) {
-			lastTransaction = env.txs[env.tcount-1]
-			env.txs = env.txs[0 : env.tcount-1]
-			break
 		}
 	}
 

--- a/miner/taiko_worker.go
+++ b/miner/taiko_worker.go
@@ -320,7 +320,7 @@ loop:
 			env.tcount++
 			txs.Shift()
 
-			// Encode and compress the txList, if the byte length is > maxBytesPerTxList, remove the latest tx.
+			// Encode and compress the txList, if the byte length is > maxBytesPerTxList, remove the latest tx and break.
 			b, err := encodeAndComporeessTxList(env.txs)
 			if err != nil {
 				log.Trace("Failed to rlp encode and compress the pending transaction %s: %w", tx.Hash(), err)

--- a/miner/taiko_worker.go
+++ b/miner/taiko_worker.go
@@ -327,7 +327,7 @@ func (w *worker) commitL2Transactions(
 		}
 
 		// Encode and compress the txList, if the byte length is > maxBytesPerTxList, remove the latest tx and break.
-		b, err := encodeAndComporeessTxList(append(env.txs, tx))
+		b, err := encodeAndComporeessTxList(env.txs)
 		if err != nil {
 			log.Trace("Failed to rlp encode and compress the pending transaction %s: %w", tx.Hash(), err)
 			txs.Pop()


### PR DESCRIPTION
Also, think there may be an some double counting in your taiko_worker.go code when calculating if the total tx len is within the maxBytesPerTxList limit.

this check: https://github.com/taikoxyz/taiko-geth/blob/30a615b4c3aafd0d395309035d58b86ff53c8eb0/miner/taiko_worker.go#L330 appends the current tx length before calling encodeAndComporeessTxList
However, if the transaction was successful it should have already been added to env.txs here: https://github.com/taikoxyz/taiko-geth/blob/30a615b4c3aafd0d395309035d58b86ff53c8eb0/miner/worker.go#L764

You will also run this check even if the tx failed and wasn't added to the tx list, which seems unecassary.

To fix I think you just need to move the maxBytesPerTxList check before committing the tx. Happy to PR this in if I haven't missed anything.