### PR TITLE
fix(txpool): basefee requires mintip to not be nil.

### DIFF
--- a/miner/taiko_worker.go
+++ b/miner/taiko_worker.go
@@ -44,7 +44,7 @@ func (w *worker) BuildTransactionsLists(
 	}
 
 	// Check if tx pool is empty at first.
-	if len(w.eth.TxPool().Pending(txpool.PendingFilter{BaseFee: uint256.MustFromBig(baseFee), OnlyPlainTxs: true})) == 0 {
+	if len(w.eth.TxPool().Pending(txpool.PendingFilter{MinTip: uint256.NewInt(minTip), BaseFee: uint256.MustFromBig(baseFee), OnlyPlainTxs: true})) == 0 {
 		return txsLists, nil
 	}
 


### PR DESCRIPTION
https://github.com/taikoxyz/taiko-geth/blob/882a6cd3294cd1c74eac37fbc37c54e64f0dc363/core/txpool/legacypool/legacypool.go#L550


The `BaseFee` is only effective if `MinTip` is not `nil`.