### PR TITLE
chore(consensus): change `SetHeadL1Origin` && `UpdateL1Origin` to `taikoauth_` namespace

### DIFF
--- a/eth/taiko_api_backend.go
+++ b/eth/taiko_api_backend.go
@@ -76,14 +76,14 @@ func NewTaikoAuthAPIBackend(eth *Ethereum) *TaikoAuthAPIBackend {
 }
 
 // SetHeadL1Origin sets the latest L2 block's corresponding L1 origin.
-func (s *TaikoAuthAPIBackend) SetHeadL1Origin(blockID *math.HexOrDecimal256) *big.Int {
-	rawdb.WriteHeadL1Origin(s.eth.ChainDb(), (*big.Int)(blockID))
+func (a *TaikoAuthAPIBackend) SetHeadL1Origin(blockID *math.HexOrDecimal256) *big.Int {
+	rawdb.WriteHeadL1Origin(a.eth.ChainDb(), (*big.Int)(blockID))
 	return (*big.Int)(blockID)
 }
 
 // UpdateL1Origin updates the L2 block's corresponding L1 origin.
-func (s *TaikoAuthAPIBackend) UpdateL1Origin(l1Origin *rawdb.L1Origin) *rawdb.L1Origin {
-	rawdb.WriteL1Origin(s.eth.ChainDb(), l1Origin.BlockID, l1Origin)
+func (a *TaikoAuthAPIBackend) UpdateL1Origin(l1Origin *rawdb.L1Origin) *rawdb.L1Origin {
+	rawdb.WriteL1Origin(a.eth.ChainDb(), l1Origin.BlockID, l1Origin)
 	return l1Origin
 }
 

--- a/eth/taiko_api_backend.go
+++ b/eth/taiko_api_backend.go
@@ -60,18 +60,6 @@ func (s *TaikoAPIBackend) L1OriginByID(blockID *math.HexOrDecimal256) (*rawdb.L1
 	return l1Origin, nil
 }
 
-// SetHeadL1Origin sets the latest L2 block's corresponding L1 origin.
-func (s *TaikoAPIBackend) SetHeadL1Origin(blockID *math.HexOrDecimal256) *big.Int {
-	rawdb.WriteHeadL1Origin(s.eth.ChainDb(), (*big.Int)(blockID))
-	return (*big.Int)(blockID)
-}
-
-// UpdateL1Origin updates the L2 block's corresponding L1 origin.
-func (s *TaikoAPIBackend) UpdateL1Origin(l1Origin *rawdb.L1Origin) *rawdb.L1Origin {
-	rawdb.WriteL1Origin(s.eth.ChainDb(), l1Origin.BlockID, l1Origin)
-	return l1Origin
-}
-
 // GetSyncMode returns the node sync mode.
 func (s *TaikoAPIBackend) GetSyncMode() (string, error) {
 	return s.eth.config.SyncMode.String(), nil
@@ -85,6 +73,18 @@ type TaikoAuthAPIBackend struct {
 // NewTaikoAuthAPIBackend creates a new TaikoAuthAPIBackend instance.
 func NewTaikoAuthAPIBackend(eth *Ethereum) *TaikoAuthAPIBackend {
 	return &TaikoAuthAPIBackend{eth}
+}
+
+// SetHeadL1Origin sets the latest L2 block's corresponding L1 origin.
+func (s *TaikoAuthAPIBackend) SetHeadL1Origin(blockID *math.HexOrDecimal256) *big.Int {
+	rawdb.WriteHeadL1Origin(s.eth.ChainDb(), (*big.Int)(blockID))
+	return (*big.Int)(blockID)
+}
+
+// UpdateL1Origin updates the L2 block's corresponding L1 origin.
+func (s *TaikoAuthAPIBackend) UpdateL1Origin(l1Origin *rawdb.L1Origin) *rawdb.L1Origin {
+	rawdb.WriteL1Origin(s.eth.ChainDb(), l1Origin.BlockID, l1Origin)
+	return l1Origin
 }
 
 // TxPoolContent retrieves the transaction pool content with the given upper limits.


### PR DESCRIPTION
Expose the two APIs to public is unsafe.