### PR TITLE
chore: log `BuildPayloadArgs` and its id

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -472,6 +472,9 @@ func (api *ConsensusAPI) forkchoiceUpdated(update engine.ForkchoiceStateV1, payl
 				TxListHash:   &txListHash,
 			}
 			id := args.Id()
+
+			log.Debug(fmt.Sprintf("BuildPayloadArgs: %v. Id: %v", args, id))
+
 			// If we already are busy generating this work, then we do not need
 			// to start a second process.
 			if api.localBlocks.has(id) {


### PR DESCRIPTION
Adds a small debug log for the `BuildPayloadArgs` and its id during a FCU call. I think it's helpful to debug payload id mismatches between taiko-driver and taiko-geth.

We do log in taiko-driver, as we can see here: https://github.com/taikoxyz/taiko-mono/blob/f799a8e3fce54d1f300ebe055b5c4754a369c888/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/common.go#L314-L334. Having a taiko-geth counterpart would be helpful, otherwise we only see an opaque identifier as difference.

I hope the formatting of the string is correct with such types, can you please double check?