### PR TITLE
feat(rawdb): introduce `batchToBlock` mapping

### DIFF
--- a/beacon/engine/gen_blockmetadata.go
+++ b/beacon/engine/gen_blockmetadata.go
@@ -5,6 +5,7 @@ package engine
 import (
 	"encoding/json"
 	"errors"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -19,6 +20,7 @@ func (b BlockMetadata) MarshalJSON() ([]byte, error) {
 		GasLimit    uint64         `json:"gasLimit"     gencodec:"required"`
 		Timestamp   hexutil.Uint64 `json:"timestamp"    gencodec:"required"`
 		MixHash     common.Hash    `json:"mixHash"      gencodec:"required"`
+		BatchID     *big.Int       `json:"batchId"`
 		TxList      hexutil.Bytes  `json:"txList"          gencodec:"required"`
 		ExtraData   []byte         `json:"extraData"       gencodec:"required"`
 	}
@@ -27,6 +29,7 @@ func (b BlockMetadata) MarshalJSON() ([]byte, error) {
 	enc.GasLimit = b.GasLimit
 	enc.Timestamp = hexutil.Uint64(b.Timestamp)
 	enc.MixHash = b.MixHash
+	enc.BatchID = b.BatchID
 	enc.TxList = b.TxList
 	enc.ExtraData = b.ExtraData
 	return json.Marshal(&enc)
@@ -39,6 +42,7 @@ func (b *BlockMetadata) UnmarshalJSON(input []byte) error {
 		GasLimit    *uint64         `json:"gasLimit"     gencodec:"required"`
 		Timestamp   *hexutil.Uint64 `json:"timestamp"    gencodec:"required"`
 		MixHash     *common.Hash    `json:"mixHash"      gencodec:"required"`
+		BatchID     *big.Int        `json:"batchId"`
 		TxList      *hexutil.Bytes  `json:"txList"          gencodec:"required"`
 		ExtraData   []byte          `json:"extraData"       gencodec:"required"`
 	}
@@ -62,6 +66,9 @@ func (b *BlockMetadata) UnmarshalJSON(input []byte) error {
 		return errors.New("missing required field 'mixHash' for BlockMetadata")
 	}
 	b.MixHash = *dec.MixHash
+	if dec.BatchID != nil {
+		b.BatchID = dec.BatchID
+	}
 	if dec.TxList == nil {
 		return errors.New("missing required field 'txList' for BlockMetadata")
 	}

--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -72,8 +72,9 @@ type BlockMetadata struct {
 	MixHash     common.Hash    `json:"mixHash"      gencodec:"required"`
 
 	// Extra fields required in taiko-geth.
-	TxList    []byte `json:"txList"          gencodec:"required"`
-	ExtraData []byte `json:"extraData"       gencodec:"required"`
+	BatchID   *big.Int `json:"batchId"`
+	TxList    []byte   `json:"txList"          gencodec:"required"`
+	ExtraData []byte   `json:"extraData"       gencodec:"required"`
 }
 
 // CHANGE(taiko): JSON type overrides for BlockMetadata.

--- a/core/rawdb/taiko_l1_origin.go
+++ b/core/rawdb/taiko_l1_origin.go
@@ -14,8 +14,9 @@ import (
 
 var (
 	// Database key prefix for L2 block's L1Origin.
-	l1OriginPrefix  = []byte("TKO:L1O")
-	headL1OriginKey = []byte("TKO:LastL1O")
+	l1OriginPrefix      = []byte("TKO:L1O")
+	batchToBlockPrefixy = []byte("TKO:B2B")
+	headL1OriginKey     = []byte("TKO:LastL1O")
 )
 
 // l1OriginKey calculates the L1Origin key.
@@ -23,6 +24,13 @@ var (
 func l1OriginKey(blockID *big.Int) []byte {
 	data, _ := (*math.HexOrDecimal256)(blockID).MarshalText()
 	return append(l1OriginPrefix, data...)
+}
+
+// batchToBlockKey calculates the batch to block key.
+// batchToBlockPrefix + batch ID -> batchToBlockKey
+func batchToBlockKey(batch *big.Int) []byte {
+	data, _ := (*math.HexOrDecimal256)(batch).MarshalText()
+	return append(batchToBlockPrefixy, data...)
 }
 
 //go:generate go run github.com/fjl/gencodec -type L1Origin -field-override l1OriginMarshaling -out gen_taiko_l1_origin.go
@@ -118,6 +126,30 @@ func ReadHeadL1Origin(db ethdb.KeyValueReader) (*big.Int, error) {
 	if err := blockID.UnmarshalText(data); err != nil {
 		log.Error("Unmarshal L1Origin unmarshal error", "error", err)
 		return nil, fmt.Errorf("invalid L1Origin unmarshal: %w", err)
+	}
+
+	return (*big.Int)(blockID), nil
+}
+
+// WriteBatchToBlock stores the mapping from batch ID to block ID.
+func WriteBatchToBlock(db ethdb.KeyValueWriter, batch *big.Int, blockID *big.Int) {
+	data, _ := (*math.HexOrDecimal256)(blockID).MarshalText()
+	if err := db.Put(batchToBlockKey(batch), data); err != nil {
+		log.Crit("Failed to store batch to block mapping", "error", err)
+	}
+}
+
+// ReadBatchToBlock retrieves the block ID corresponding to the given batch ID.
+func ReadBatchToBlock(db ethdb.KeyValueReader, batch *big.Int) (*big.Int, error) {
+	data, _ := db.Get(batchToBlockKey(batch))
+	if len(data) == 0 {
+		return nil, nil
+	}
+
+	blockID := new(math.HexOrDecimal256)
+	if err := blockID.UnmarshalText(data); err != nil {
+		log.Error("Unmarshal batch to block unmarshal error", "error", err)
+		return nil, fmt.Errorf("invalid batch to block unmarshal: %w", err)
 	}
 
 	return (*big.Int)(blockID), nil

--- a/core/rawdb/taiko_l1_origin.go
+++ b/core/rawdb/taiko_l1_origin.go
@@ -14,9 +14,9 @@ import (
 
 var (
 	// Database key prefix for L2 block's L1Origin.
-	l1OriginPrefix      = []byte("TKO:L1O")
-	batchToBlockPrefixy = []byte("TKO:B2B")
-	headL1OriginKey     = []byte("TKO:LastL1O")
+	l1OriginPrefix     = []byte("TKO:L1O")
+	batchToBlockPrefix = []byte("TKO:B2B")
+	headL1OriginKey    = []byte("TKO:LastL1O")
 )
 
 // l1OriginKey calculates the L1Origin key.
@@ -30,7 +30,7 @@ func l1OriginKey(blockID *big.Int) []byte {
 // batchToBlockPrefix + batch ID -> batchToBlockKey
 func batchToBlockKey(batch *big.Int) []byte {
 	data, _ := (*math.HexOrDecimal256)(batch).MarshalText()
-	return append(batchToBlockPrefixy, data...)
+	return append(batchToBlockPrefix, data...)
 }
 
 //go:generate go run github.com/fjl/gencodec -type L1Origin -field-override l1OriginMarshaling -out gen_taiko_l1_origin.go

--- a/core/rawdb/taiko_l1_origin.go
+++ b/core/rawdb/taiko_l1_origin.go
@@ -14,9 +14,9 @@ import (
 
 var (
 	// Database key prefix for L2 block's L1Origin.
-	l1OriginPrefix     = []byte("TKO:L1O")
-	batchToBlockPrefix = []byte("TKO:B2B")
-	headL1OriginKey    = []byte("TKO:LastL1O")
+	l1OriginPrefix         = []byte("TKO:L1O")
+	batchToLastBlockPrefix = []byte("TKO:B2B")
+	headL1OriginKey        = []byte("TKO:LastL1O")
 )
 
 // l1OriginKey calculates the L1Origin key.
@@ -26,11 +26,11 @@ func l1OriginKey(blockID *big.Int) []byte {
 	return append(l1OriginPrefix, data...)
 }
 
-// batchToBlockKey calculates the batch to block key.
-// batchToBlockPrefix + batch ID -> batchToBlockKey
-func batchToBlockKey(batch *big.Int) []byte {
+// batchToLastBlockKey calculates the batch to block key.
+// batchToBlockPrefix + batch ID -> batchToLastBlockKey
+func batchToLastBlockKey(batch *big.Int) []byte {
 	data, _ := (*math.HexOrDecimal256)(batch).MarshalText()
-	return append(batchToBlockPrefix, data...)
+	return append(batchToLastBlockPrefix, data...)
 }
 
 //go:generate go run github.com/fjl/gencodec -type L1Origin -field-override l1OriginMarshaling -out gen_taiko_l1_origin.go
@@ -131,17 +131,17 @@ func ReadHeadL1Origin(db ethdb.KeyValueReader) (*big.Int, error) {
 	return (*big.Int)(blockID), nil
 }
 
-// WriteBatchToBlock stores the mapping from batch ID to block ID.
-func WriteBatchToBlock(db ethdb.KeyValueWriter, batch *big.Int, blockID *big.Int) {
+// WriteBatchToLastBlockID stores the mapping from batch ID to the last block ID in this batch.
+func WriteBatchToLastBlockID(db ethdb.KeyValueWriter, batch *big.Int, blockID *big.Int) {
 	data, _ := (*math.HexOrDecimal256)(blockID).MarshalText()
-	if err := db.Put(batchToBlockKey(batch), data); err != nil {
+	if err := db.Put(batchToLastBlockKey(batch), data); err != nil {
 		log.Crit("Failed to store batch to block mapping", "error", err)
 	}
 }
 
-// ReadBatchToBlock retrieves the block ID corresponding to the given batch ID.
-func ReadBatchToBlock(db ethdb.KeyValueReader, batch *big.Int) (*big.Int, error) {
-	data, _ := db.Get(batchToBlockKey(batch))
+// ReadBatchToLastBlockID retrieves the block ID corresponding to the last block ID in this batch.
+func ReadBatchToLastBlockID(db ethdb.KeyValueReader, batch *big.Int) (*big.Int, error) {
+	data, _ := db.Get(batchToLastBlockKey(batch))
 	if len(data) == 0 {
 		return nil, nil
 	}

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -480,7 +480,8 @@ func (api *ConsensusAPI) forkchoiceUpdated(update engine.ForkchoiceStateV1, payl
 			}
 			id := args.Id()
 
-			log.Debug("PayloadArgs",
+			log.Debug(
+				"Payload arguments",
 				"parent", args.Parent.Hex(),
 				"timestamp", args.Timestamp,
 				"feeRecipient", args.FeeRecipient.Hex(),
@@ -514,6 +515,7 @@ func (api *ConsensusAPI) forkchoiceUpdated(update engine.ForkchoiceStateV1, payl
 			// Write the head L1Origin, only when it's not a preconfirmation block.
 			if !l1Origin.IsPreconfBlock() {
 				rawdb.WriteHeadL1Origin(api.eth.ChainDb(), l1Origin.BlockID)
+				rawdb.WriteBatchToBlock(api.eth.ChainDb(), l1Origin.BlockID, l1Origin.BlockID)
 			}
 
 			return valid(&id), nil

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -515,7 +515,10 @@ func (api *ConsensusAPI) forkchoiceUpdated(update engine.ForkchoiceStateV1, payl
 			// Write the head L1Origin, only when it's not a preconfirmation block.
 			if !l1Origin.IsPreconfBlock() {
 				rawdb.WriteHeadL1Origin(api.eth.ChainDb(), l1Origin.BlockID)
-				rawdb.WriteBatchToBlock(api.eth.ChainDb(), l1Origin.BlockID, l1Origin.BlockID)
+				// Write the batch to block mapping if the batch ID is given.
+				if payloadAttributes.BlockMetadata.BatchID != nil {
+					rawdb.WriteBatchToBlock(api.eth.ChainDb(), payloadAttributes.BlockMetadata.BatchID, l1Origin.BlockID)
+				}
 			}
 
 			return valid(&id), nil

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -517,7 +517,7 @@ func (api *ConsensusAPI) forkchoiceUpdated(update engine.ForkchoiceStateV1, payl
 				rawdb.WriteHeadL1Origin(api.eth.ChainDb(), l1Origin.BlockID)
 				// Write the batch to block mapping if the batch ID is given.
 				if payloadAttributes.BlockMetadata.BatchID != nil {
-					rawdb.WriteBatchToBlock(api.eth.ChainDb(), payloadAttributes.BlockMetadata.BatchID, l1Origin.BlockID)
+					rawdb.WriteBatchToLastBlockID(api.eth.ChainDb(), payloadAttributes.BlockMetadata.BatchID, l1Origin.BlockID)
 				}
 			}
 

--- a/eth/taiko_api_backend.go
+++ b/eth/taiko_api_backend.go
@@ -93,6 +93,12 @@ func (a *TaikoAuthAPIBackend) SetHeadL1Origin(blockID *math.HexOrDecimal256) *bi
 	return (*big.Int)(blockID)
 }
 
+// SetHeadL1Origin sets the latest L2 block's corresponding L1 origin.
+func (a *TaikoAuthAPIBackend) SetBatchToBlock(batchID *math.HexOrDecimal256, blockID *math.HexOrDecimal256) *big.Int {
+	rawdb.WriteBatchToBlock(a.eth.ChainDb(), (*big.Int)(batchID), (*big.Int)(blockID))
+	return (*big.Int)(batchID)
+}
+
 // UpdateL1Origin updates the L2 block's corresponding L1 origin.
 func (a *TaikoAuthAPIBackend) UpdateL1Origin(l1Origin *rawdb.L1Origin) *rawdb.L1Origin {
 	rawdb.WriteL1Origin(a.eth.ChainDb(), l1Origin.BlockID, l1Origin)

--- a/eth/taiko_api_backend.go
+++ b/eth/taiko_api_backend.go
@@ -60,9 +60,9 @@ func (s *TaikoAPIBackend) L1OriginByID(blockID *math.HexOrDecimal256) (*rawdb.L1
 	return l1Origin, nil
 }
 
-// L1OriginByBatchID returns the L1 origin of the last block for the given batch.
-func (s *TaikoAPIBackend) L1OriginByBatchID(batchID *math.HexOrDecimal256) (*rawdb.L1Origin, error) {
-	blockID, err := rawdb.ReadBatchToBlock(s.eth.ChainDb(), (*big.Int)(batchID))
+// LastL1OriginByBatchID returns the L1 origin of the last block for the given batch.
+func (s *TaikoAPIBackend) LastL1OriginByBatchID(batchID *math.HexOrDecimal256) (*rawdb.L1Origin, error) {
+	blockID, err := rawdb.ReadBatchToLastBlockID(s.eth.ChainDb(), (*big.Int)(batchID))
 	if err != nil {
 		return nil, err
 	}
@@ -93,9 +93,12 @@ func (a *TaikoAuthAPIBackend) SetHeadL1Origin(blockID *math.HexOrDecimal256) *bi
 	return (*big.Int)(blockID)
 }
 
-// SetHeadL1Origin sets the latest L2 block's corresponding L1 origin.
-func (a *TaikoAuthAPIBackend) SetBatchToBlock(batchID *math.HexOrDecimal256, blockID *math.HexOrDecimal256) *big.Int {
-	rawdb.WriteBatchToBlock(a.eth.ChainDb(), (*big.Int)(batchID), (*big.Int)(blockID))
+// SetBatchToLastBlock sets the mapping from batch ID to the last block ID in this batch.
+func (a *TaikoAuthAPIBackend) SetBatchToLastBlock(
+	batchID *math.HexOrDecimal256,
+	blockID *math.HexOrDecimal256,
+) *big.Int {
+	rawdb.WriteBatchToLastBlockID(a.eth.ChainDb(), (*big.Int)(batchID), (*big.Int)(blockID))
 	return (*big.Int)(batchID)
 }
 

--- a/eth/taiko_api_backend.go
+++ b/eth/taiko_api_backend.go
@@ -60,6 +60,18 @@ func (s *TaikoAPIBackend) L1OriginByID(blockID *math.HexOrDecimal256) (*rawdb.L1
 	return l1Origin, nil
 }
 
+// L1OriginByBatchID returns the L1 origin of the last block for the given batch.
+func (s *TaikoAPIBackend) L1OriginByBatchID(batchID *math.HexOrDecimal256) (*rawdb.L1Origin, error) {
+	blockID, err := rawdb.ReadBatchToBlock(s.eth.ChainDb(), (*big.Int)(batchID))
+	if err != nil {
+		return nil, err
+	}
+	if blockID == nil {
+		return nil, ethereum.NotFound
+	}
+	return s.L1OriginByID((*math.HexOrDecimal256)(blockID))
+}
+
 // GetSyncMode returns the node sync mode.
 func (s *TaikoAPIBackend) GetSyncMode() (string, error) {
 	return s.eth.config.SyncMode.String(), nil


### PR DESCRIPTION
In Shasta fork, we can't know the last block ID in a batch / proposal anymore, so the node has to record it by itself.