### PR TITLE
fix(taiko-api): fix `SetHeadL1Origin` RPC Return Type

### DIFF
--- a/eth/taiko_api_backend.go
+++ b/eth/taiko_api_backend.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/log"
@@ -76,9 +77,9 @@ func NewTaikoAuthAPIBackend(eth *Ethereum) *TaikoAuthAPIBackend {
 }
 
 // SetHeadL1Origin sets the latest L2 block's corresponding L1 origin.
-func (a *TaikoAuthAPIBackend) SetHeadL1Origin(blockID *math.HexOrDecimal256) *big.Int {
+func (a *TaikoAuthAPIBackend) SetHeadL1Origin(blockID *math.HexOrDecimal256) *hexutil.Big {
 	rawdb.WriteHeadL1Origin(a.eth.ChainDb(), (*big.Int)(blockID))
-	return (*big.Int)(blockID)
+	return (*hexutil.Big)(blockID)
 }
 
 // UpdateL1Origin updates the L2 block's corresponding L1 origin.


### PR DESCRIPTION
To ensure the `taikoAuth_setHeadL1Origin` RPC is compatible with other execution clients, `SetHeadL1Origin` should return `*hexutil.Big` instead of `*big.Int`. 
The existing RPC in Geth follow the similar pattern (returning `*hexutil.Big`), e.g., [GetBalance](https://github.com/taikoxyz/taiko-geth/blob/fb1c1c891b217b5b2ad3011f1888409b9fe49117/internal/ethapi/api.go#L325) , [MaxPriorityFeePerGas](https://github.com/taikoxyz/taiko-geth/blob/fb1c1c891b217b5b2ad3011f1888409b9fe49117/internal/ethapi/api.go#L81)
The client code changes to ensure it is consumed correctly are present here: https://github.com/taikoxyz/taiko-mono/pull/20234