### PR TITLE
feat(consensus): introduce `ShastaExtraDataLen` constant && update `verifyHeader`

### DIFF
--- a/consensus/taiko/consensus.go
+++ b/consensus/taiko/consensus.go
@@ -140,9 +140,16 @@ func (t *Taiko) verifyHeader(chain consensus.ChainHeaderReader, header, parent *
 		return fmt.Errorf("extra-data too long: %d > %d", len(header.Extra), params.MaximumExtraDataSize)
 	}
 
-	// Timestamp should later than or equal to parent (when many L2 blocks included in one L1 block)
-	if header.Time < parent.Time {
-		return ErrOlderBlockTime
+	// Shasta fork enforces a strict timestamp increase, other forks allow equal
+	// timestamps (multiple L2 blocks per L1 block scenario).
+	if t.chainConfig.IsShasta(header.Time) {
+		if header.Time <= parent.Time {
+			return ErrOlderBlockTime
+		}
+	} else {
+		if header.Time < parent.Time {
+			return ErrOlderBlockTime
+		}
 	}
 
 	// Verify that the block number is parent's +1

--- a/consensus/taiko/consensus.go
+++ b/consensus/taiko/consensus.go
@@ -177,6 +177,9 @@ func (t *Taiko) verifyHeader(chain consensus.ChainHeaderReader, header, parent *
 
 	// Verify the header's EIP-4396 attributes.
 	if t.chainConfig.IsShasta(header.Time) {
+		if len(header.Extra) < params.ShastaExtraDataLen {
+			return fmt.Errorf("Shasta extra-data too short: %d < %d", len(header.Extra), params.ShastaExtraDataLen)
+		}
 		var parentBlockTime uint64
 		if header.Number.Cmp(common.Big1) > 0 {
 			if ancestorBlock := chain.GetHeaderByHash(parent.ParentHash); ancestorBlock != nil {

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -712,6 +712,9 @@ func DecodeOntakeExtraData(extradata []byte) uint8 {
 // CHANGE(taiko): decodes an Shasta block's extradata, returns basefeeSharingPctg configurations,
 // the corresponding encoding function in protocol is `LibProposing._encodeGasConfigs`.
 func DecodeShastaExtraData(extradata []byte) (uint8, bool) {
+	if len(extradata) < params.ShastaExtraDataLen {
+		return 0, false
+	}
 	// First byte: basefeeSharingPctg
 	basefeeSharingPctg := extradata[0]
 	// Second byte: isLowBondProposal (lowest bit)

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -132,6 +132,7 @@ const (
 	DefaultElasticityMultiplier     = 2          // Bounds the maximum gas limit an EIP-1559 block may have.
 	InitialBaseFee                  = 1000000000 // Initial base fee for EIP-1559 blocks.
 	ShastaInitialBaseFee            = 25_000_000 // CHANGE(taiko): add ShastaInitialBaseFee for Shasta fork
+	ShastaExtraDataLen              = 2          // CHANGE(taiko): Shasta extradata encodes basefee share pctg and low bond flag
 
 	MaxCodeSize     = 24576           // Maximum bytecode to permit for a contract
 	MaxInitCodeSize = 2 * MaxCodeSize // Maximum initcode to permit in a creation transaction and create instructions


### PR DESCRIPTION
- add `params.ShastaExtraDataLen` so the Shasta extradata size lives beside other fork-specific parameters
- reuse the constant in taiko consensus header validation and `core.DecodeShastaExtraData` to keep decoding and verification aligned