### PR TITLE
fix(eth): update L1 origin only with correct data

### DIFF
--- a/eth/taiko_api_backend.go
+++ b/eth/taiko_api_backend.go
@@ -178,10 +178,60 @@ func (a *TaikoAuthAPIBackend) SetBatchToLastBlock(
 	return (*hexutil.Big)(batchID)
 }
 
+func mergeL1Origin(existing *rawdb.L1Origin, update *rawdb.L1Origin) *rawdb.L1Origin {
+	if existing == nil {
+		return update
+	}
+	if update == nil {
+		return existing
+	}
+
+	merged := *existing
+
+	if update.BlockID != nil {
+		merged.BlockID = update.BlockID
+	}
+	if update.L2BlockHash != (common.Hash{}) {
+		merged.L2BlockHash = update.L2BlockHash
+	}
+	if update.L1BlockHeight != nil {
+		// Treat height=0 as "set" only if accompanied by a non-zero hash (e.g. genesis).
+		if update.L1BlockHeight.Sign() > 0 || (update.L1BlockHeight.Sign() == 0 && update.L1BlockHash != (common.Hash{})) {
+			merged.L1BlockHeight = update.L1BlockHeight
+		}
+	}
+	if update.L1BlockHash != (common.Hash{}) {
+		merged.L1BlockHash = update.L1BlockHash
+	}
+	if update.BuildPayloadArgsID != ([8]byte{}) {
+		merged.BuildPayloadArgsID = update.BuildPayloadArgsID
+	}
+	// Never downgrade forced-inclusion status.
+	merged.IsForcedInclusion = merged.IsForcedInclusion || update.IsForcedInclusion
+	if update.Signature != ([65]byte{}) {
+		merged.Signature = update.Signature
+	}
+
+	return &merged
+}
+
 // UpdateL1Origin updates the L2 block's corresponding L1 origin.
 func (a *TaikoAuthAPIBackend) UpdateL1Origin(l1Origin *rawdb.L1Origin) *rawdb.L1Origin {
-	rawdb.WriteL1Origin(a.eth.ChainDb(), l1Origin.BlockID, l1Origin)
-	return l1Origin
+	if l1Origin == nil || l1Origin.BlockID == nil {
+		log.Warn("Invalid L1Origin update", "l1Origin", l1Origin)
+		return l1Origin
+	}
+
+	existing, err := rawdb.ReadL1Origin(a.eth.ChainDb(), l1Origin.BlockID)
+	if err != nil {
+		log.Warn("Failed to read existing L1Origin, overwriting", "blockID", l1Origin.BlockID, "error", err)
+		rawdb.WriteL1Origin(a.eth.ChainDb(), l1Origin.BlockID, l1Origin)
+		return l1Origin
+	}
+
+	merged := mergeL1Origin(existing, l1Origin)
+	rawdb.WriteL1Origin(a.eth.ChainDb(), merged.BlockID, merged)
+	return merged
 }
 
 // SetL1OriginSignature sets the L1 origin signature for the given block ID.

--- a/eth/taiko_api_backend_test.go
+++ b/eth/taiko_api_backend_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/taiko"
+	"github.com/ethereum/go-ethereum/core/rawdb"
 )
 
 func TestAnchorV4ProposalID(t *testing.T) {
@@ -76,5 +77,87 @@ func TestAnchorV4ProposalID(t *testing.T) {
 func TestAnchorV4ProposalIDInvalidData(t *testing.T) {
 	if _, err := AnchorV4ProposalID([]byte{0x10, 0x0f}); err == nil {
 		t.Fatal("expected error for malformed calldata")
+	}
+}
+
+func TestMergeL1Origin_PreservesPopulatedFieldsOnPartialUpdate(t *testing.T) {
+	existing := &rawdb.L1Origin{
+		BlockID:       big.NewInt(123),
+		L2BlockHash:   common.HexToHash("0x01"),
+		L1BlockHeight: big.NewInt(100),
+		L1BlockHash:   common.HexToHash("0x02"),
+	}
+
+	var buildID [8]byte
+	buildID[0] = 0xAA
+	var sig [65]byte
+	sig[0] = 0xBB
+	update := &rawdb.L1Origin{
+		BlockID:            big.NewInt(123),
+		BuildPayloadArgsID: buildID,
+		Signature:          sig,
+		// L1 fields intentionally omitted (zero values).
+	}
+
+	merged := mergeL1Origin(existing, update)
+	if merged == nil {
+		t.Fatal("expected merged origin")
+	}
+	if merged.L1BlockHeight == nil || merged.L1BlockHeight.Cmp(big.NewInt(100)) != 0 {
+		t.Fatalf("expected L1BlockHeight preserved, got %v", merged.L1BlockHeight)
+	}
+	if merged.L1BlockHash != common.HexToHash("0x02") {
+		t.Fatalf("expected L1BlockHash preserved, got %v", merged.L1BlockHash)
+	}
+	if merged.BuildPayloadArgsID != buildID {
+		t.Fatalf("expected BuildPayloadArgsID updated, got %x", merged.BuildPayloadArgsID)
+	}
+	if merged.Signature != sig {
+		t.Fatalf("expected Signature updated")
+	}
+}
+
+func TestMergeL1Origin_UpdatesPreconfToAnchored(t *testing.T) {
+	existing := &rawdb.L1Origin{
+		BlockID:       big.NewInt(1),
+		L2BlockHash:   common.HexToHash("0x10"),
+		L1BlockHeight: nil,
+		L1BlockHash:   common.Hash{},
+	}
+
+	update := &rawdb.L1Origin{
+		BlockID:       big.NewInt(1),
+		L1BlockHeight: big.NewInt(999),
+		L1BlockHash:   common.HexToHash("0x20"),
+	}
+
+	merged := mergeL1Origin(existing, update)
+	if merged.L1BlockHeight == nil || merged.L1BlockHeight.Cmp(big.NewInt(999)) != 0 {
+		t.Fatalf("expected L1BlockHeight updated, got %v", merged.L1BlockHeight)
+	}
+	if merged.L1BlockHash != common.HexToHash("0x20") {
+		t.Fatalf("expected L1BlockHash updated, got %v", merged.L1BlockHash)
+	}
+}
+
+func TestMergeL1Origin_AllowsHeightZeroWhenHashSet(t *testing.T) {
+	existing := &rawdb.L1Origin{
+		BlockID:       big.NewInt(1),
+		L1BlockHeight: big.NewInt(7),
+		L1BlockHash:   common.HexToHash("0x07"),
+	}
+
+	update := &rawdb.L1Origin{
+		BlockID:       big.NewInt(1),
+		L1BlockHeight: big.NewInt(0),
+		L1BlockHash:   common.HexToHash("0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"),
+	}
+
+	merged := mergeL1Origin(existing, update)
+	if merged.L1BlockHeight == nil || merged.L1BlockHeight.Sign() != 0 {
+		t.Fatalf("expected L1BlockHeight updated to 0, got %v", merged.L1BlockHeight)
+	}
+	if merged.L1BlockHash != update.L1BlockHash {
+		t.Fatalf("expected L1BlockHash updated, got %v", merged.L1BlockHash)
 	}
 }


### PR DESCRIPTION
fixes: https://github.com/taikoxyz/taiko-mono/issues/21010

The prover-relayer isn’t getting “stuck at L1 genesis”. It’s getting stuck because its reorg-check compares:

  - l1HashNew: the canonical L1 hash at l1Height (here l1Height=0, so d4e567… = Ethereum genesis), versus
  - l1HashOld: the L1 hash recorded in the L2 execution engine’s L1Origin for that batch/block.

  In the failing case, the L2 node returns an L1Origin with L1BlockHeight=0 and L1BlockHash=0x000… (unset). That makes the comparison always “mismatch”, so CheckL1Reorg logs “Reorg detected” and the prover
  resets its L1 cursor back one batch (lastHandledBatchIDNew=1,343,948). On the next loop it reprocesses the same BatchProposed, hits the same unset origin again, and repeats forever.

  Why it happens after restarting L1:

  - The logs show transient infra/RPC issues during/after restart (DNS failures to the L1 endpoint + timeouts waiting for L2 headers). During this unstable window, the L2 node’s origin metadata can be
    temporarily incomplete or can be overwritten by partial origin updates, leading to the {height:0, hash:0} origin that triggers the false reorg loop.

  Why restarting the prover fixes it:

  - After some time, the L2 node resumes returning a populated origin (or the prover restarts past the bad state), so the reorg-check stops seeing the zeroed origin and proceeds normally.

  The taiko-geth fix addresses the root cause: taikoAuth_updateL1Origin now merges updates instead of overwriting, so partial updates can’t wipe already-populated L1BlockHeight/L1BlockHash and
  create the l1Height=0 / l1HashOld=0 false-reorg condition.