### PR TITLE
fix(miner): change rpc response taikoAuth_txPoolContent from PascalCase to camelCase

### DIFF
--- a/miner/taiko_miner.go
+++ b/miner/taiko_miner.go
@@ -11,9 +11,9 @@ import (
 // PreBuiltTxList is a pre-built transaction list based on the latest chain state,
 // with estimated gas used / bytes.
 type PreBuiltTxList struct {
-	TxList           types.Transactions
-	EstimatedGasUsed uint64
-	BytesLength      uint64
+	TxList           types.Transactions `json:"txList"`
+	EstimatedGasUsed uint64             `json:"estimatedGasUsed"`
+	BytesLength      uint64             `json:"bytesLength"`
 }
 
 // SealBlockWith mines and seals a block without changing the canonical chain.

--- a/scripts/taiko_generate_jsonrpc.go
+++ b/scripts/taiko_generate_jsonrpc.go
@@ -276,11 +276,11 @@ func main() {
 			"*miner.PreBuiltTxList": map[string]interface{}{
 				"type": "object",
 				"properties": map[string]interface{}{
-					"TxList":           map[string]interface{}{"type": "array"},
-					"EstimatedGasUsed": map[string]interface{}{"type": "integer", "examples": []int{10000}},
-					"BytesLength":      map[string]interface{}{"type": "integer", "examples": []int{10000}},
+					"txList":           map[string]interface{}{"type": "array"},
+					"estimatedGasUsed": map[string]interface{}{"type": "integer", "examples": []int{10000}},
+					"bytesLength":      map[string]interface{}{"type": "integer", "examples": []int{10000}},
 				},
-				"required": []string{"TxList", "EstimatedGasUsed", "BytesLength"},
+				"required": []string{"txList", "estimatedGasUsed", "bytesLength"},
 			},
 			"*big.Int": map[string]interface{}{
 				"type":     "integer",


### PR DESCRIPTION
Taiko Geth currently returns response for RPCs `taikoAuth_txPoolContent` & `taikoAuth_txPoolContentWithMinTip` in PascalCase format (TxList, EstimatedGasUsed etc.) but it should be using camelCase to follow the existing Ethereum RPC standard.
Issue link: https://github.com/taikoxyz/taiko-mono/issues/21188