### PR TITLE
feat(consensus): add Shasta EOP flag and remove batch-to-last-block DB mapping

### DIFF
--- a/consensus/taiko/consensus.go
+++ b/consensus/taiko/consensus.go
@@ -184,8 +184,8 @@ func (t *Taiko) verifyHeader(chain consensus.ChainHeaderReader, header, parent *
 
 	// Verify the header's EIP-4396 attributes.
 	if t.chainConfig.IsShasta(header.Time) {
-		if len(header.Extra) < params.ShastaExtraDataLen {
-			return fmt.Errorf("Shasta extra-data too short: %d < %d", len(header.Extra), params.ShastaExtraDataLen)
+		if len(header.Extra) != params.ShastaExtraDataLen {
+			return fmt.Errorf("Shasta extra-data length invalid: %d != %d", len(header.Extra), params.ShastaExtraDataLen)
 		}
 		var parentBlockTime uint64
 		if header.Number.Cmp(common.Big1) > 0 {

--- a/core/rawdb/taiko_l1_origin.go
+++ b/core/rawdb/taiko_l1_origin.go
@@ -6,7 +6,6 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
@@ -15,9 +14,8 @@ import (
 
 var (
 	// Database key prefix for L2 block's L1Origin.
-	l1OriginPrefix         = []byte("TKO:L1O")
-	batchToLastBlockPrefix = []byte("TKO:B2B")
-	headL1OriginKey        = []byte("TKO:LastL1O")
+	l1OriginPrefix  = []byte("TKO:L1O")
+	headL1OriginKey = []byte("TKO:LastL1O")
 )
 
 // l1OriginKey calculates the L1Origin key.
@@ -25,13 +23,6 @@ var (
 func l1OriginKey(blockID *big.Int) []byte {
 	data, _ := (*math.HexOrDecimal256)(blockID).MarshalText()
 	return append(l1OriginPrefix, data...)
-}
-
-// batchToLastBlockKey calculates the batch to block key.
-// batchToBlockPrefix + batch ID -> batchToLastBlockKey
-func batchToLastBlockKey(batch *big.Int) []byte {
-	data, _ := (*math.HexOrDecimal256)(batch).MarshalText()
-	return append(batchToLastBlockPrefix, data...)
 }
 
 //go:generate go run github.com/fjl/gencodec -type L1Origin -field-override l1OriginMarshaling -out gen_taiko_l1_origin.go
@@ -130,28 +121,4 @@ func ReadHeadL1Origin(db ethdb.KeyValueReader) (*big.Int, error) {
 	}
 
 	return (*big.Int)(blockID), nil
-}
-
-// WriteBatchToLastBlockID stores the mapping from batch ID to the last block ID in this batch.
-func WriteBatchToLastBlockID(db ethdb.KeyValueWriter, batch *big.Int, blockID *big.Int) {
-	data, _ := (*math.HexOrDecimal256)(blockID).MarshalText()
-	if err := db.Put(batchToLastBlockKey(batch), data); err != nil {
-		log.Crit("Failed to store batch to block mapping", "error", err)
-	}
-}
-
-// ReadBatchToLastBlockID retrieves the block ID corresponding to the last block ID in this batch.
-func ReadBatchToLastBlockID(db ethdb.KeyValueReader, batch *big.Int) (*hexutil.Big, error) {
-	data, _ := db.Get(batchToLastBlockKey(batch))
-	if len(data) == 0 {
-		return nil, nil
-	}
-
-	blockID := new(math.HexOrDecimal256)
-	if err := blockID.UnmarshalText(data); err != nil {
-		log.Error("Unmarshal batch to block unmarshal error", "error", err)
-		return nil, fmt.Errorf("invalid batch to block unmarshal: %w", err)
-	}
-
-	return (*hexutil.Big)(blockID), nil
 }

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -712,14 +712,15 @@ func DecodeShastaBasefeeSharingPctg(extra []byte) uint8 {
 	return extra[params.ShastaExtraDataBasefeeSharingPctgIndex]
 }
 
-// CHANGE(taiko): DecodeShastaProposalID decodes the proposalId from bytes 1..6.
-func DecodeShastaProposalID(extra []byte) (*big.Int, error) {
-	if len(extra) < params.ShastaExtraDataLen {
-		return nil, fmt.Errorf("extraData too short for proposalId: %d", len(extra))
+// CHANGE(taiko): DecodeShastaProposalID decodes the proposalId from bytes 1..6 and endOfProposal from byte 7.
+func DecodeShastaProposalID(extra []byte) (*big.Int, bool, error) {
+	if len(extra) != params.ShastaExtraDataLen {
+		return nil, false, fmt.Errorf("extraData length invalid for proposalId: %d != %d", len(extra), params.ShastaExtraDataLen)
 	}
 	start := params.ShastaExtraDataProposalIDIndex
 	end := start + params.ShastaExtraDataProposalIDLength
-	return new(big.Int).SetBytes(extra[start:end]), nil
+	endOfProposal := extra[params.ShastaExtraDataEndOfProposalIndex] != 0
+	return new(big.Int).SetBytes(extra[start:end]), endOfProposal, nil
 }
 
 // CHANGE(taiko): decodes an Ontake/Pacaya block's extradata, returns basefeeSharingPctg.

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -499,10 +499,6 @@ func (api *ConsensusAPI) forkchoiceUpdated(update engine.ForkchoiceStateV1, payl
 				rawdb.WriteL1Origin(api.eth.ChainDb(), l1Origin.BlockID, l1Origin)
 				if !l1Origin.IsPreconfBlock() {
 					rawdb.WriteHeadL1Origin(api.eth.ChainDb(), l1Origin.BlockID)
-					// Write the batch to block mapping if the batch ID is given.
-					if payloadAttributes.BlockMetadata.BatchID != nil {
-						rawdb.WriteBatchToLastBlockID(api.eth.ChainDb(), payloadAttributes.BlockMetadata.BatchID, l1Origin.BlockID)
-					}
 				}
 				return valid(&id), nil
 			}
@@ -522,10 +518,6 @@ func (api *ConsensusAPI) forkchoiceUpdated(update engine.ForkchoiceStateV1, payl
 			// Write the head L1Origin, only when it's not a preconfirmation block.
 			if !l1Origin.IsPreconfBlock() {
 				rawdb.WriteHeadL1Origin(api.eth.ChainDb(), l1Origin.BlockID)
-				// Write the batch to block mapping if the batch ID is given.
-				if payloadAttributes.BlockMetadata.BatchID != nil {
-					rawdb.WriteBatchToLastBlockID(api.eth.ChainDb(), payloadAttributes.BlockMetadata.BatchID, l1Origin.BlockID)
-				}
 			}
 
 			return valid(&id), nil

--- a/eth/taiko_api_backend.go
+++ b/eth/taiko_api_backend.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/taiko"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/miner"
 )
@@ -79,20 +80,26 @@ func (s *TaikoAPIBackend) LastBlockIDByBatchID(batchID *math.HexOrDecimal256) (*
 	currentBlock := s.eth.BlockChain().GetBlockByNumber(s.eth.blockchain.CurrentHeader().Number.Uint64())
 	targetBatchID := (*big.Int)(batchID)
 
-	for currentBlock != nil &&
-		currentBlock.Transactions().Len() > 0 &&
-		bytes.HasPrefix(currentBlock.Transactions()[0].Data(), taiko.AnchorV4Selector) {
+	// If the given batchID is greater than the head proposalID,
+	// it means the batch does not exist.
+	if isShastaBlock(currentBlock) {
+		proposalID, _, err := core.DecodeShastaProposalID(currentBlock.Header().Extra)
+		if err != nil {
+			return nil, err
+		}
+		if targetBatchID.Cmp(proposalID) > 0 {
+			return nil, fmt.Errorf("batchID %s greater than head proposalID %s", targetBatchID.String(), proposalID.String())
+		}
+	}
+
+	// Traverse backwards to find the last block of the given batchID.
+	for isShastaBlock(currentBlock) {
 		if currentBlock.NumberU64() == 0 {
 			break
 		}
 		proposalID, endOfProposal, err := core.DecodeShastaProposalID(currentBlock.Header().Extra)
 		if err != nil {
 			return nil, err
-		}
-		// If the given batchID is greater than the current proposalID,
-		// it means the batch does not exist.
-		if targetBatchID.Cmp(proposalID) > 0 {
-			return nil, fmt.Errorf("batchID %s greater than head proposalID %s", targetBatchID.String(), proposalID.String())
 		}
 		if proposalID.Cmp(targetBatchID) == 0 {
 			if !endOfProposal {
@@ -104,6 +111,18 @@ func (s *TaikoAPIBackend) LastBlockIDByBatchID(batchID *math.HexOrDecimal256) (*
 		currentBlock = s.eth.BlockChain().GetBlockByNumber(currentBlock.NumberU64() - 1)
 	}
 	return nil, ethereum.NotFound
+}
+
+// isShastaBlock checks if the given block is a Shasta block by inspecting its first transaction's data.
+func isShastaBlock(block *types.Block) bool {
+	if block == nil {
+		return false
+	}
+	txs := block.Transactions()
+	if txs.Len() == 0 {
+		return false
+	}
+	return bytes.HasPrefix(txs[0].Data(), taiko.AnchorV4Selector)
 }
 
 // GetSyncMode returns the node sync mode.

--- a/eth/taiko_api_backend.go
+++ b/eth/taiko_api_backend.go
@@ -2,6 +2,7 @@ package eth
 
 import (
 	"bytes"
+	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum"
@@ -66,31 +67,15 @@ func (s *TaikoAPIBackend) L1OriginByID(blockID *math.HexOrDecimal256) (*rawdb.L1
 
 // LastL1OriginByBatchID returns the L1 origin of the last block for the given batch.
 func (s *TaikoAPIBackend) LastL1OriginByBatchID(batchID *math.HexOrDecimal256) (*rawdb.L1Origin, error) {
-	blockID, err := rawdb.ReadBatchToLastBlockID(s.eth.ChainDb(), (*big.Int)(batchID))
+	blockID, err := s.LastBlockIDByBatchID(batchID)
 	if err != nil {
 		return nil, err
-	}
-	if blockID == nil {
-		if blockID, err = s.getLastBlockByBatchId((*big.Int)(batchID)); err != nil {
-			return nil, err
-		}
-		if blockID == nil {
-			return nil, ethereum.NotFound
-		}
 	}
 	return s.L1OriginByID((*math.HexOrDecimal256)(blockID))
 }
 
 // LastBlockIDByBatchID returns the ID of the last block for the given batch.
 func (s *TaikoAPIBackend) LastBlockIDByBatchID(batchID *math.HexOrDecimal256) (*hexutil.Big, error) {
-	blockID, err := rawdb.ReadBatchToLastBlockID(s.eth.ChainDb(), (*big.Int)(batchID))
-	if err != nil {
-		return nil, err
-	}
-	if blockID != nil {
-		return blockID, nil
-	}
-
 	return s.getLastBlockByBatchId((*big.Int)(batchID))
 }
 
@@ -109,11 +94,19 @@ func (s *TaikoAPIBackend) getLastBlockByBatchId(batchID *big.Int) (*hexutil.Big,
 		if currentBlock.NumberU64() == 0 {
 			break
 		}
-		proposalID, err := core.DecodeShastaProposalID(currentBlock.Header().Extra)
+		proposalID, endOfProposal, err := core.DecodeShastaProposalID(currentBlock.Header().Extra)
 		if err != nil {
 			return nil, err
 		}
+		// If the given batchID is greater than the current proposalID,
+		// it means the batch does not exist.
+		if batchID.Cmp(proposalID) > 0 {
+			return nil, fmt.Errorf("batchID %s greater than head proposalID %s", batchID.String(), proposalID.String())
+		}
 		if proposalID.Cmp(batchID) == 0 {
+			if !endOfProposal {
+				return nil, fmt.Errorf("endOfProposal flag not set for batch %s", batchID.String())
+			}
 			return (*hexutil.Big)(currentBlock.Number()), nil
 		}
 
@@ -136,15 +129,6 @@ func NewTaikoAuthAPIBackend(eth *Ethereum) *TaikoAuthAPIBackend {
 func (a *TaikoAuthAPIBackend) SetHeadL1Origin(blockID *math.HexOrDecimal256) *hexutil.Big {
 	rawdb.WriteHeadL1Origin(a.eth.ChainDb(), (*big.Int)(blockID))
 	return (*hexutil.Big)(blockID)
-}
-
-// SetBatchToLastBlock sets the mapping from batch ID to the last block ID in this batch.
-func (a *TaikoAuthAPIBackend) SetBatchToLastBlock(
-	batchID *math.HexOrDecimal256,
-	blockID *math.HexOrDecimal256,
-) *hexutil.Big {
-	rawdb.WriteBatchToLastBlockID(a.eth.ChainDb(), (*big.Int)(batchID), (*big.Int)(blockID))
-	return (*hexutil.Big)(batchID)
 }
 
 // UpdateL1Origin updates the L2 block's corresponding L1 origin.

--- a/eth/taiko_api_backend.go
+++ b/eth/taiko_api_backend.go
@@ -76,17 +76,8 @@ func (s *TaikoAPIBackend) LastL1OriginByBatchID(batchID *math.HexOrDecimal256) (
 
 // LastBlockIDByBatchID returns the ID of the last block for the given batch.
 func (s *TaikoAPIBackend) LastBlockIDByBatchID(batchID *math.HexOrDecimal256) (*hexutil.Big, error) {
-	return s.getLastBlockByBatchId((*big.Int)(batchID))
-}
-
-// GetSyncMode returns the node sync mode.
-func (s *TaikoAPIBackend) GetSyncMode() (string, error) {
-	return s.eth.config.SyncMode.String(), nil
-}
-
-// getLastBlockByBatchId traverses the blockchain backwards to find the last Shasta block of the given Shasta batch ID.
-func (s *TaikoAPIBackend) getLastBlockByBatchId(batchID *big.Int) (*hexutil.Big, error) {
 	currentBlock := s.eth.BlockChain().GetBlockByNumber(s.eth.blockchain.CurrentHeader().Number.Uint64())
+	targetBatchID := (*big.Int)(batchID)
 
 	for currentBlock != nil &&
 		currentBlock.Transactions().Len() > 0 &&
@@ -100,12 +91,12 @@ func (s *TaikoAPIBackend) getLastBlockByBatchId(batchID *big.Int) (*hexutil.Big,
 		}
 		// If the given batchID is greater than the current proposalID,
 		// it means the batch does not exist.
-		if batchID.Cmp(proposalID) > 0 {
-			return nil, fmt.Errorf("batchID %s greater than head proposalID %s", batchID.String(), proposalID.String())
+		if targetBatchID.Cmp(proposalID) > 0 {
+			return nil, fmt.Errorf("batchID %s greater than head proposalID %s", targetBatchID.String(), proposalID.String())
 		}
-		if proposalID.Cmp(batchID) == 0 {
+		if proposalID.Cmp(targetBatchID) == 0 {
 			if !endOfProposal {
-				return nil, fmt.Errorf("endOfProposal flag not set for batch %s", batchID.String())
+				return nil, fmt.Errorf("endOfProposal flag not set for batch %s", targetBatchID.String())
 			}
 			return (*hexutil.Big)(currentBlock.Number()), nil
 		}
@@ -113,6 +104,11 @@ func (s *TaikoAPIBackend) getLastBlockByBatchId(batchID *big.Int) (*hexutil.Big,
 		currentBlock = s.eth.BlockChain().GetBlockByNumber(currentBlock.NumberU64() - 1)
 	}
 	return nil, ethereum.NotFound
+}
+
+// GetSyncMode returns the node sync mode.
+func (s *TaikoAPIBackend) GetSyncMode() (string, error) {
+	return s.eth.config.SyncMode.String(), nil
 }
 
 // TaikoAuthAPIBackend handles L2 node related authorized RPC calls.

--- a/eth/taiko_api_backend_test.go
+++ b/eth/taiko_api_backend_test.go
@@ -1,15 +1,23 @@
 package eth
 
 import (
+	"errors"
 	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/consensus/taiko"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 func TestShastaProposalIDFromExtraData(t *testing.T) {
-	extra := []byte{0x2a, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06}
-	proposalID, err := core.DecodeShastaProposalID(extra)
+	extra := []byte{0x2a, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x01}
+	proposalID, endOfProposal, err := core.DecodeShastaProposalID(extra)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -17,10 +25,13 @@ func TestShastaProposalIDFromExtraData(t *testing.T) {
 	if proposalID.Cmp(expected) != 0 {
 		t.Fatalf("expected %s, got %s", expected.String(), proposalID.String())
 	}
+	if !endOfProposal {
+		t.Fatal("expected endOfProposal to be true")
+	}
 }
 
 func TestShastaBasefeeSharingPctgFromExtraData(t *testing.T) {
-	extra := []byte{0x64, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+	extra := []byte{0x64, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
 	if pctg := core.DecodeShastaBasefeeSharingPctg(extra); pctg != 0x64 {
 		t.Fatalf("expected 0x64, got %d", pctg)
 	}
@@ -30,7 +41,87 @@ func TestShastaBasefeeSharingPctgFromExtraData(t *testing.T) {
 }
 
 func TestShastaProposalIDFromExtraDataInvalid(t *testing.T) {
-	if _, err := core.DecodeShastaProposalID([]byte{0x01}); err == nil {
-		t.Fatal("expected error for short extradata")
+	tests := []struct {
+		name  string
+		extra []byte
+	}{
+		{
+			name:  "short",
+			extra: []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07},
+		},
+		{
+			name:  "long",
+			extra: []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09},
+		},
 	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, _, err := core.DecodeShastaProposalID(test.extra); err == nil {
+				t.Fatal("expected error for invalid extradata length")
+			}
+		})
+	}
+}
+
+func TestGetLastBlockByBatchIdRequiresEndOfProposal(t *testing.T) {
+	extra := []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00}
+	chain := newShastaTestChain(t, extra)
+	defer chain.Stop()
+	backend := &TaikoAPIBackend{eth: &Ethereum{blockchain: chain}}
+	if _, err := backend.getLastBlockByBatchId(big.NewInt(1)); err == nil {
+		t.Fatal("expected error when endOfProposal is false")
+	}
+}
+
+func TestGetLastBlockByBatchIdTooLarge(t *testing.T) {
+	extra := []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01}
+	chain := newShastaTestChain(t, extra)
+	defer chain.Stop()
+
+	backend := &TaikoAPIBackend{eth: &Ethereum{blockchain: chain}}
+	if _, err := backend.getLastBlockByBatchId(big.NewInt(2)); err == nil {
+		t.Fatal("expected error when batchID is greater than head proposalID")
+	} else if errors.Is(err, ethereum.NotFound) {
+		t.Fatal("expected direct error, got NotFound")
+	}
+}
+
+func newShastaTestChain(t *testing.T, extra []byte) *core.BlockChain {
+	t.Helper()
+
+	genesis := &core.Genesis{
+		Config: params.TestChainConfig,
+		Alloc: types.GenesisAlloc{
+			testAddr: {Balance: big.NewInt(1_000_000_000_000_000_000)},
+		},
+		BaseFee: big.NewInt(params.InitialBaseFee),
+	}
+
+	db, blocks, _ := core.GenerateChainWithGenesis(genesis, ethash.NewFaker(), 1, func(i int, gen *core.BlockGen) {
+		gen.SetExtra(extra)
+		data := append(append([]byte{}, taiko.AnchorV4Selector...), 0x00)
+		tx := types.NewTransaction(
+			gen.TxNonce(testAddr),
+			common.Address{},
+			big.NewInt(0),
+			100000,
+			big.NewInt(params.InitialBaseFee*2),
+			data,
+		)
+		signedTx, err := types.SignTx(tx, gen.Signer(), testKey)
+		if err != nil {
+			panic(err)
+		}
+		gen.AddTx(signedTx)
+	})
+
+	chain, err := core.NewBlockChain(db, nil, genesis, nil, ethash.NewFaker(), vm.Config{}, nil)
+	if err != nil {
+		t.Fatalf("failed to create blockchain: %v", err)
+	}
+	if _, err := chain.InsertChain(blocks); err != nil {
+		t.Fatalf("failed to insert chain: %v", err)
+	}
+	return chain
 }

--- a/eth/taiko_api_backend_test.go
+++ b/eth/taiko_api_backend_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
 	"github.com/ethereum/go-ethereum/consensus/taiko"
 	"github.com/ethereum/go-ethereum/core"
@@ -64,23 +65,23 @@ func TestShastaProposalIDFromExtraDataInvalid(t *testing.T) {
 	}
 }
 
-func TestGetLastBlockByBatchIdRequiresEndOfProposal(t *testing.T) {
+func TestLastBlockIDByBatchIDRequiresEndOfProposal(t *testing.T) {
 	extra := []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00}
 	chain := newShastaTestChain(t, extra)
 	defer chain.Stop()
 	backend := &TaikoAPIBackend{eth: &Ethereum{blockchain: chain}}
-	if _, err := backend.getLastBlockByBatchId(big.NewInt(1)); err == nil {
+	if _, err := backend.LastBlockIDByBatchID((*math.HexOrDecimal256)(big.NewInt(1))); err == nil {
 		t.Fatal("expected error when endOfProposal is false")
 	}
 }
 
-func TestGetLastBlockByBatchIdTooLarge(t *testing.T) {
+func TestLastBlockIDByBatchIDTooLarge(t *testing.T) {
 	extra := []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01}
 	chain := newShastaTestChain(t, extra)
 	defer chain.Stop()
 
 	backend := &TaikoAPIBackend{eth: &Ethereum{blockchain: chain}}
-	if _, err := backend.getLastBlockByBatchId(big.NewInt(2)); err == nil {
+	if _, err := backend.LastBlockIDByBatchID((*math.HexOrDecimal256)(big.NewInt(2))); err == nil {
 		t.Fatal("expected error when batchID is greater than head proposalID")
 	} else if errors.Is(err, ethereum.NotFound) {
 		t.Fatal("expected direct error, got NotFound")

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -137,7 +137,8 @@ const (
 	ShastaExtraDataBasefeeSharingPctgIndex = 0
 	ShastaExtraDataProposalIDIndex         = 1
 	ShastaExtraDataProposalIDLength        = 6
-	ShastaExtraDataLen                     = 1 + ShastaExtraDataProposalIDLength
+	ShastaExtraDataEndOfProposalIndex      = 7
+	ShastaExtraDataLen                     = 8
 
 	MaxCodeSize     = 24576           // Maximum bytecode to permit for a contract
 	MaxInitCodeSize = 2 * MaxCodeSize // Maximum initcode to permit in a creation transaction and create instructions


### PR DESCRIPTION
ref: https://github.com/taikoxyz/taiko-mono/pull/21216


  ## Summary

  - Enforce Shasta extraData strict length = 8 and decode (proposalId, endOfProposal) from bytes 1..7.
  - Use EOP flag to resolve last block by batch; error if EOP is false or batchID > head proposalID.
  - Remove batch→lastBlock DB mapping and related RPC/DB writes.

  ## Changes

  - Update Shasta extraData constants and decode API.
  - Adjust consensus check to require len(extraData) == 8.
  - getLastBlockByBatchId now uses EOP flag and validates batchID vs head proposalID.
  - Remove batchToLastBlockPrefix and Read/WriteBatchToLastBlockID, plus call sites.
  - Add/extend tests for Shasta decoding and last-block lookup behavior.