### PR TITLE
chore(eth): return `NotFound` for missing batch in `LastBlockIDByBatchID`

### DIFF
--- a/eth/taiko_api_backend.go
+++ b/eth/taiko_api_backend.go
@@ -2,7 +2,6 @@ package eth
 
 import (
 	"bytes"
-	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum"
@@ -88,7 +87,7 @@ func (s *TaikoAPIBackend) LastBlockIDByBatchID(batchID *math.HexOrDecimal256) (*
 			return nil, err
 		}
 		if targetBatchID.Cmp(proposalID) > 0 {
-			return nil, fmt.Errorf("batchID %s greater than head proposalID %s", targetBatchID.String(), proposalID.String())
+			return nil, ethereum.NotFound
 		}
 	}
 
@@ -103,7 +102,7 @@ func (s *TaikoAPIBackend) LastBlockIDByBatchID(batchID *math.HexOrDecimal256) (*
 		}
 		if proposalID.Cmp(targetBatchID) == 0 {
 			if !endOfProposal {
-				return nil, fmt.Errorf("endOfProposal flag not set for batch %s", targetBatchID.String())
+				return nil, ethereum.NotFound
 			}
 			return (*hexutil.Big)(currentBlock.Number()), nil
 		}

--- a/eth/taiko_api_backend_test.go
+++ b/eth/taiko_api_backend_test.go
@@ -72,6 +72,8 @@ func TestLastBlockIDByBatchIDRequiresEndOfProposal(t *testing.T) {
 	backend := &TaikoAPIBackend{eth: &Ethereum{blockchain: chain}}
 	if _, err := backend.LastBlockIDByBatchID((*math.HexOrDecimal256)(big.NewInt(1))); err == nil {
 		t.Fatal("expected error when endOfProposal is false")
+	} else if !errors.Is(err, ethereum.NotFound) {
+		t.Fatalf("expected NotFound, got %v", err)
 	}
 }
 
@@ -83,8 +85,8 @@ func TestLastBlockIDByBatchIDTooLarge(t *testing.T) {
 	backend := &TaikoAPIBackend{eth: &Ethereum{blockchain: chain}}
 	if _, err := backend.LastBlockIDByBatchID((*math.HexOrDecimal256)(big.NewInt(2))); err == nil {
 		t.Fatal("expected error when batchID is greater than head proposalID")
-	} else if errors.Is(err, ethereum.NotFound) {
-		t.Fatal("expected direct error, got NotFound")
+	} else if !errors.Is(err, ethereum.NotFound) {
+		t.Fatalf("expected NotFound, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary


  - Normalize `LastBlockIDByBatchID` to return `ethereum.NotFound` when the batch is beyond head or not finalized.
  - Update tests to assert `NotFound` for those cases.
  - Motivation: improve compatibility with the current `taiko-client` and `taiko-client-rs`.