### PR TITLE
feat(consensus): restore batch-to-last-block mapping and bound Shasta batch lookup

### DIFF
--- a/consensus/taiko/consensus.go
+++ b/consensus/taiko/consensus.go
@@ -184,8 +184,8 @@ func (t *Taiko) verifyHeader(chain consensus.ChainHeaderReader, header, parent *
 
 	// Verify the header's EIP-4396 attributes.
 	if t.chainConfig.IsShasta(header.Time) {
-		if len(header.Extra) != params.ShastaExtraDataLen {
-			return fmt.Errorf("Shasta extra-data length invalid: %d != %d", len(header.Extra), params.ShastaExtraDataLen)
+		if len(header.Extra) < params.ShastaExtraDataLen {
+			return fmt.Errorf("Shasta extra-data too short: %d < %d", len(header.Extra), params.ShastaExtraDataLen)
 		}
 		var parentBlockTime uint64
 		if header.Number.Cmp(common.Big1) > 0 {

--- a/core/rawdb/taiko_l1_origin.go
+++ b/core/rawdb/taiko_l1_origin.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
@@ -14,8 +15,9 @@ import (
 
 var (
 	// Database key prefix for L2 block's L1Origin.
-	l1OriginPrefix  = []byte("TKO:L1O")
-	headL1OriginKey = []byte("TKO:LastL1O")
+	l1OriginPrefix         = []byte("TKO:L1O")
+	batchToLastBlockPrefix = []byte("TKO:B2B")
+	headL1OriginKey        = []byte("TKO:LastL1O")
 )
 
 // l1OriginKey calculates the L1Origin key.
@@ -23,6 +25,13 @@ var (
 func l1OriginKey(blockID *big.Int) []byte {
 	data, _ := (*math.HexOrDecimal256)(blockID).MarshalText()
 	return append(l1OriginPrefix, data...)
+}
+
+// batchToLastBlockKey calculates the batch to block key.
+// batchToBlockPrefix + batch ID -> batchToLastBlockKey
+func batchToLastBlockKey(batch *big.Int) []byte {
+	data, _ := (*math.HexOrDecimal256)(batch).MarshalText()
+	return append(batchToLastBlockPrefix, data...)
 }
 
 //go:generate go run github.com/fjl/gencodec -type L1Origin -field-override l1OriginMarshaling -out gen_taiko_l1_origin.go
@@ -121,4 +130,28 @@ func ReadHeadL1Origin(db ethdb.KeyValueReader) (*big.Int, error) {
 	}
 
 	return (*big.Int)(blockID), nil
+}
+
+// WriteBatchToLastBlockID stores the mapping from batch ID to the last block ID in this batch.
+func WriteBatchToLastBlockID(db ethdb.KeyValueWriter, batch *big.Int, blockID *big.Int) {
+	data, _ := (*math.HexOrDecimal256)(blockID).MarshalText()
+	if err := db.Put(batchToLastBlockKey(batch), data); err != nil {
+		log.Crit("Failed to store batch to block mapping", "error", err)
+	}
+}
+
+// ReadBatchToLastBlockID retrieves the block ID corresponding to the last block ID in this batch.
+func ReadBatchToLastBlockID(db ethdb.KeyValueReader, batch *big.Int) (*hexutil.Big, error) {
+	data, _ := db.Get(batchToLastBlockKey(batch))
+	if len(data) == 0 {
+		return nil, nil
+	}
+
+	blockID := new(math.HexOrDecimal256)
+	if err := blockID.UnmarshalText(data); err != nil {
+		log.Error("Unmarshal batch to block unmarshal error", "error", err)
+		return nil, fmt.Errorf("invalid batch to block unmarshal: %w", err)
+	}
+
+	return (*hexutil.Big)(blockID), nil
 }

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -712,15 +712,14 @@ func DecodeShastaBasefeeSharingPctg(extra []byte) uint8 {
 	return extra[params.ShastaExtraDataBasefeeSharingPctgIndex]
 }
 
-// CHANGE(taiko): DecodeShastaProposalID decodes the proposalId from bytes 1..6 and endOfProposal from byte 7.
-func DecodeShastaProposalID(extra []byte) (*big.Int, bool, error) {
-	if len(extra) != params.ShastaExtraDataLen {
-		return nil, false, fmt.Errorf("extraData length invalid for proposalId: %d != %d", len(extra), params.ShastaExtraDataLen)
+// CHANGE(taiko): DecodeShastaProposalID decodes the proposalId from bytes 1..6.
+func DecodeShastaProposalID(extra []byte) (*big.Int, error) {
+	if len(extra) < params.ShastaExtraDataLen {
+		return nil, fmt.Errorf("extraData too short for proposalId: %d", len(extra))
 	}
 	start := params.ShastaExtraDataProposalIDIndex
 	end := start + params.ShastaExtraDataProposalIDLength
-	endOfProposal := extra[params.ShastaExtraDataEndOfProposalIndex] != 0
-	return new(big.Int).SetBytes(extra[start:end]), endOfProposal, nil
+	return new(big.Int).SetBytes(extra[start:end]), nil
 }
 
 // CHANGE(taiko): decodes an Ontake/Pacaya block's extradata, returns basefeeSharingPctg.

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -501,6 +501,10 @@ func (api *ConsensusAPI) forkchoiceUpdated(update engine.ForkchoiceStateV1, payl
 				rawdb.WriteL1Origin(api.eth.ChainDb(), l1Origin.BlockID, l1Origin)
 				if !l1Origin.IsPreconfBlock() {
 					rawdb.WriteHeadL1Origin(api.eth.ChainDb(), l1Origin.BlockID)
+					// Write the batch to block mapping if the batch ID is given.
+					if payloadAttributes.BlockMetadata.BatchID != nil {
+						rawdb.WriteBatchToLastBlockID(api.eth.ChainDb(), payloadAttributes.BlockMetadata.BatchID, l1Origin.BlockID)
+					}
 				}
 				return valid(&id), nil
 			}
@@ -520,6 +524,10 @@ func (api *ConsensusAPI) forkchoiceUpdated(update engine.ForkchoiceStateV1, payl
 			// Write the head L1Origin, only when it's not a preconfirmation block.
 			if !l1Origin.IsPreconfBlock() {
 				rawdb.WriteHeadL1Origin(api.eth.ChainDb(), l1Origin.BlockID)
+				// Write the batch to block mapping if the batch ID is given.
+				if payloadAttributes.BlockMetadata.BatchID != nil {
+					rawdb.WriteBatchToLastBlockID(api.eth.ChainDb(), payloadAttributes.BlockMetadata.BatchID, l1Origin.BlockID)
+				}
 			}
 
 			return valid(&id), nil

--- a/eth/taiko_api_backend.go
+++ b/eth/taiko_api_backend.go
@@ -2,7 +2,6 @@ package eth
 
 import (
 	"bytes"
-	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum"
@@ -12,7 +11,6 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/taiko"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/miner"
 )
@@ -68,66 +66,60 @@ func (s *TaikoAPIBackend) L1OriginByID(blockID *math.HexOrDecimal256) (*rawdb.L1
 
 // LastL1OriginByBatchID returns the L1 origin of the last block for the given batch.
 func (s *TaikoAPIBackend) LastL1OriginByBatchID(batchID *math.HexOrDecimal256) (*rawdb.L1Origin, error) {
-	blockID, err := s.LastBlockIDByBatchID(batchID)
+	blockID, err := rawdb.ReadBatchToLastBlockID(s.eth.ChainDb(), (*big.Int)(batchID))
 	if err != nil {
 		return nil, err
+	}
+	if blockID == nil {
+		if blockID, err = s.getLastBlockByBatchId((*big.Int)(batchID)); err != nil {
+			return nil, err
+		}
+		if blockID == nil {
+			return nil, ethereum.NotFound
+		}
 	}
 	return s.L1OriginByID((*math.HexOrDecimal256)(blockID))
 }
 
 // LastBlockIDByBatchID returns the ID of the last block for the given batch.
 func (s *TaikoAPIBackend) LastBlockIDByBatchID(batchID *math.HexOrDecimal256) (*hexutil.Big, error) {
-	currentBlock := s.eth.BlockChain().GetBlockByNumber(s.eth.blockchain.CurrentHeader().Number.Uint64())
-	targetBatchID := (*big.Int)(batchID)
-
-	// If the given batchID is greater than the head proposalID,
-	// it means the batch does not exist.
-	if isShastaBlock(currentBlock) {
-		proposalID, _, err := core.DecodeShastaProposalID(currentBlock.Header().Extra)
-		if err != nil {
-			return nil, err
-		}
-		if targetBatchID.Cmp(proposalID) > 0 {
-			return nil, fmt.Errorf("batchID %s greater than head proposalID %s", targetBatchID.String(), proposalID.String())
-		}
+	blockID, err := rawdb.ReadBatchToLastBlockID(s.eth.ChainDb(), (*big.Int)(batchID))
+	if err != nil {
+		return nil, err
+	}
+	if blockID != nil {
+		return blockID, nil
 	}
 
-	// Traverse backwards to find the last block of the given batchID.
-	for isShastaBlock(currentBlock) {
+	return s.getLastBlockByBatchId((*big.Int)(batchID))
+}
+
+// GetSyncMode returns the node sync mode.
+func (s *TaikoAPIBackend) GetSyncMode() (string, error) {
+	return s.eth.config.SyncMode.String(), nil
+}
+
+// getLastBlockByBatchId traverses the blockchain backwards to find the last Shasta block of the given Shasta batch ID.
+func (s *TaikoAPIBackend) getLastBlockByBatchId(batchID *big.Int) (*hexutil.Big, error) {
+	currentBlock := s.eth.BlockChain().GetBlockByNumber(s.eth.blockchain.CurrentHeader().Number.Uint64())
+
+	for currentBlock != nil &&
+		currentBlock.Transactions().Len() > 0 &&
+		bytes.HasPrefix(currentBlock.Transactions()[0].Data(), taiko.AnchorV4Selector) {
 		if currentBlock.NumberU64() == 0 {
 			break
 		}
-		proposalID, endOfProposal, err := core.DecodeShastaProposalID(currentBlock.Header().Extra)
+		proposalID, err := core.DecodeShastaProposalID(currentBlock.Header().Extra)
 		if err != nil {
 			return nil, err
 		}
-		if proposalID.Cmp(targetBatchID) == 0 {
-			if !endOfProposal {
-				return nil, fmt.Errorf("endOfProposal flag not set for batch %s", targetBatchID.String())
-			}
+		if proposalID.Cmp(batchID) == 0 {
 			return (*hexutil.Big)(currentBlock.Number()), nil
 		}
 
 		currentBlock = s.eth.BlockChain().GetBlockByNumber(currentBlock.NumberU64() - 1)
 	}
 	return nil, ethereum.NotFound
-}
-
-// isShastaBlock checks if the given block is a Shasta block by inspecting its first transaction's data.
-func isShastaBlock(block *types.Block) bool {
-	if block == nil {
-		return false
-	}
-	txs := block.Transactions()
-	if txs.Len() == 0 {
-		return false
-	}
-	return bytes.HasPrefix(txs[0].Data(), taiko.AnchorV4Selector)
-}
-
-// GetSyncMode returns the node sync mode.
-func (s *TaikoAPIBackend) GetSyncMode() (string, error) {
-	return s.eth.config.SyncMode.String(), nil
 }
 
 // TaikoAuthAPIBackend handles L2 node related authorized RPC calls.
@@ -144,6 +136,15 @@ func NewTaikoAuthAPIBackend(eth *Ethereum) *TaikoAuthAPIBackend {
 func (a *TaikoAuthAPIBackend) SetHeadL1Origin(blockID *math.HexOrDecimal256) *hexutil.Big {
 	rawdb.WriteHeadL1Origin(a.eth.ChainDb(), (*big.Int)(blockID))
 	return (*hexutil.Big)(blockID)
+}
+
+// SetBatchToLastBlock sets the mapping from batch ID to the last block ID in this batch.
+func (a *TaikoAuthAPIBackend) SetBatchToLastBlock(
+	batchID *math.HexOrDecimal256,
+	blockID *math.HexOrDecimal256,
+) *hexutil.Big {
+	rawdb.WriteBatchToLastBlockID(a.eth.ChainDb(), (*big.Int)(batchID), (*big.Int)(blockID))
+	return (*hexutil.Big)(batchID)
 }
 
 // UpdateL1Origin updates the L2 block's corresponding L1 origin.

--- a/eth/taiko_api_backend.go
+++ b/eth/taiko_api_backend.go
@@ -2,7 +2,6 @@ package eth
 
 import (
 	"bytes"
-	"errors"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum"
@@ -14,11 +13,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/miner"
-)
-
-// ErrProposalLastBlockUncertain indicates the last block for the proposal is not yet deterministic.
-var ErrProposalLastBlockUncertain = errors.New(
-	"proposal last block uncertain: BatchToLastBlockID missing and no newer proposal observed",
 )
 
 // TaikoAPIBackend handles L2 node related RPC calls.
@@ -107,10 +101,7 @@ func (s *TaikoAPIBackend) GetSyncMode() (string, error) {
 
 // getLastBlockByBatchId traverses the blockchain backwards to find the last Shasta block of the given Shasta batch ID.
 func (s *TaikoAPIBackend) getLastBlockByBatchId(batchID *big.Int) (*hexutil.Big, error) {
-	var (
-		headNumber   = s.eth.blockchain.CurrentHeader().Number.Uint64()
-		currentBlock = s.eth.BlockChain().GetBlockByNumber(headNumber)
-	)
+	currentBlock := s.eth.BlockChain().GetBlockByNumber(s.eth.blockchain.CurrentHeader().Number.Uint64())
 
 	for currentBlock != nil &&
 		currentBlock.Transactions().Len() > 0 &&
@@ -123,10 +114,6 @@ func (s *TaikoAPIBackend) getLastBlockByBatchId(batchID *big.Int) (*hexutil.Big,
 			return nil, err
 		}
 		if proposalID.Cmp(batchID) == 0 {
-			if currentBlock.NumberU64() == headNumber {
-				// Head block match without BatchToLastBlockID mapping is not definitive.
-				return nil, ErrProposalLastBlockUncertain
-			}
 			return (*hexutil.Big)(currentBlock.Number()), nil
 		}
 

--- a/eth/taiko_api_backend.go
+++ b/eth/taiko_api_backend.go
@@ -101,7 +101,13 @@ func (s *TaikoAPIBackend) GetSyncMode() (string, error) {
 
 // getLastBlockByBatchId traverses the blockchain backwards to find the last Shasta block of the given Shasta batch ID.
 func (s *TaikoAPIBackend) getLastBlockByBatchId(batchID *big.Int) (*hexutil.Big, error) {
-	currentBlock := s.eth.BlockChain().GetBlockByNumber(s.eth.blockchain.CurrentHeader().Number.Uint64())
+	// Start from head L1 origin block ID to bound the scan.
+	l1Origin, err := s.HeadL1Origin()
+	if err != nil {
+		return nil, err
+	}
+
+	currentBlock := s.eth.BlockChain().GetBlockByNumber(l1Origin.BlockID.Uint64())
 
 	for currentBlock != nil &&
 		currentBlock.Transactions().Len() > 0 &&

--- a/eth/taiko_api_backend.go
+++ b/eth/taiko_api_backend.go
@@ -2,6 +2,7 @@ package eth
 
 import (
 	"bytes"
+	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum"
@@ -87,7 +88,7 @@ func (s *TaikoAPIBackend) LastBlockIDByBatchID(batchID *math.HexOrDecimal256) (*
 			return nil, err
 		}
 		if targetBatchID.Cmp(proposalID) > 0 {
-			return nil, ethereum.NotFound
+			return nil, fmt.Errorf("batchID %s greater than head proposalID %s", targetBatchID.String(), proposalID.String())
 		}
 	}
 
@@ -102,7 +103,7 @@ func (s *TaikoAPIBackend) LastBlockIDByBatchID(batchID *math.HexOrDecimal256) (*
 		}
 		if proposalID.Cmp(targetBatchID) == 0 {
 			if !endOfProposal {
-				return nil, ethereum.NotFound
+				return nil, fmt.Errorf("endOfProposal flag not set for batch %s", targetBatchID.String())
 			}
 			return (*hexutil.Big)(currentBlock.Number()), nil
 		}

--- a/eth/taiko_api_backend.go
+++ b/eth/taiko_api_backend.go
@@ -2,6 +2,7 @@ package eth
 
 import (
 	"bytes"
+	"errors"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum"
@@ -13,6 +14,11 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/miner"
+)
+
+// ErrProposalLastBlockUncertain indicates the last block for the proposal is not yet deterministic.
+var ErrProposalLastBlockUncertain = errors.New(
+	"proposal last block uncertain: BatchToLastBlockID missing and no newer proposal observed",
 )
 
 // TaikoAPIBackend handles L2 node related RPC calls.
@@ -101,7 +107,10 @@ func (s *TaikoAPIBackend) GetSyncMode() (string, error) {
 
 // getLastBlockByBatchId traverses the blockchain backwards to find the last Shasta block of the given Shasta batch ID.
 func (s *TaikoAPIBackend) getLastBlockByBatchId(batchID *big.Int) (*hexutil.Big, error) {
-	currentBlock := s.eth.BlockChain().GetBlockByNumber(s.eth.blockchain.CurrentHeader().Number.Uint64())
+	var (
+		headNumber   = s.eth.blockchain.CurrentHeader().Number.Uint64()
+		currentBlock = s.eth.BlockChain().GetBlockByNumber(headNumber)
+	)
 
 	for currentBlock != nil &&
 		currentBlock.Transactions().Len() > 0 &&
@@ -114,6 +123,10 @@ func (s *TaikoAPIBackend) getLastBlockByBatchId(batchID *big.Int) (*hexutil.Big,
 			return nil, err
 		}
 		if proposalID.Cmp(batchID) == 0 {
+			if currentBlock.NumberU64() == headNumber {
+				// Head block match without BatchToLastBlockID mapping is not definitive.
+				return nil, ErrProposalLastBlockUncertain
+			}
 			return (*hexutil.Big)(currentBlock.Number()), nil
 		}
 

--- a/eth/taiko_api_backend.go
+++ b/eth/taiko_api_backend.go
@@ -101,13 +101,7 @@ func (s *TaikoAPIBackend) GetSyncMode() (string, error) {
 
 // getLastBlockByBatchId traverses the blockchain backwards to find the last Shasta block of the given Shasta batch ID.
 func (s *TaikoAPIBackend) getLastBlockByBatchId(batchID *big.Int) (*hexutil.Big, error) {
-	// Start from head L1 origin block ID to bound the scan.
-	l1Origin, err := s.HeadL1Origin()
-	if err != nil {
-		return nil, err
-	}
-
-	currentBlock := s.eth.BlockChain().GetBlockByNumber(l1Origin.BlockID.Uint64())
+	currentBlock := s.eth.BlockChain().GetBlockByNumber(s.eth.blockchain.CurrentHeader().Number.Uint64())
 
 	for currentBlock != nil &&
 		currentBlock.Transactions().Len() > 0 &&

--- a/eth/taiko_api_backend_test.go
+++ b/eth/taiko_api_backend_test.go
@@ -1,18 +1,10 @@
 package eth
 
 import (
-	"errors"
 	"math/big"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/consensus/ethash"
-	"github.com/ethereum/go-ethereum/consensus/taiko"
 	"github.com/ethereum/go-ethereum/core"
-	"github.com/ethereum/go-ethereum/core/rawdb"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/core/vm"
-	"github.com/ethereum/go-ethereum/params"
 )
 
 func TestShastaProposalIDFromExtraData(t *testing.T) {
@@ -40,55 +32,5 @@ func TestShastaBasefeeSharingPctgFromExtraData(t *testing.T) {
 func TestShastaProposalIDFromExtraDataInvalid(t *testing.T) {
 	if _, err := core.DecodeShastaProposalID([]byte{0x01}); err == nil {
 		t.Fatal("expected error for short extradata")
-	}
-}
-
-func TestGetLastBlockByBatchIdUncertainAtHead(t *testing.T) {
-	proposalBytes := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}
-	proposalID := new(big.Int).SetBytes(proposalBytes)
-	extra := append([]byte{0x00}, proposalBytes...)
-	data := make([]byte, len(taiko.AnchorV4Selector))
-	copy(data, taiko.AnchorV4Selector)
-
-	genesis := &core.Genesis{
-		Config: params.TestChainConfig,
-		Alloc: types.GenesisAlloc{
-			testAddr: {Balance: big.NewInt(1_000_000_000_000_000_000)},
-		},
-	}
-	engine := ethash.NewFaker()
-
-	_, blocks, _ := core.GenerateChainWithGenesis(genesis, engine, 1, func(i int, b *core.BlockGen) {
-		b.SetExtra(extra)
-		tx := types.NewTx(&types.LegacyTx{
-			Nonce:    0,
-			To:       &common.Address{1},
-			Value:    big.NewInt(0),
-			Gas:      50_000,
-			GasPrice: b.BaseFee(),
-			Data:     data,
-		})
-		signed, err := types.SignTx(tx, types.HomesteadSigner{}, testKey)
-		if err != nil {
-			t.Fatalf("failed to sign tx: %v", err)
-		}
-		b.AddTx(signed)
-	})
-
-	chain, err := core.NewBlockChain(rawdb.NewMemoryDatabase(), nil, genesis, nil, engine, vm.Config{}, nil)
-	if err != nil {
-		t.Fatalf("failed to create chain: %v", err)
-	}
-	if _, err := chain.InsertChain(blocks); err != nil {
-		t.Fatalf("failed to insert chain: %v", err)
-	}
-
-	backend := &TaikoAPIBackend{eth: &Ethereum{blockchain: chain}}
-	blockID, err := backend.getLastBlockByBatchId(proposalID)
-	if !errors.Is(err, ErrProposalLastBlockUncertain) {
-		t.Fatalf("expected ErrProposalLastBlockUncertain, got %v", err)
-	}
-	if blockID != nil {
-		t.Fatalf("expected nil blockID, got %v", blockID)
 	}
 }

--- a/eth/taiko_api_backend_test.go
+++ b/eth/taiko_api_backend_test.go
@@ -4,16 +4,7 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/ethereum/go-ethereum"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/consensus/ethash"
-	"github.com/ethereum/go-ethereum/consensus/taiko"
 	"github.com/ethereum/go-ethereum/core"
-	"github.com/ethereum/go-ethereum/core/rawdb"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/core/vm"
-	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/params"
 )
 
 func TestShastaProposalIDFromExtraData(t *testing.T) {
@@ -42,73 +33,4 @@ func TestShastaProposalIDFromExtraDataInvalid(t *testing.T) {
 	if _, err := core.DecodeShastaProposalID([]byte{0x01}); err == nil {
 		t.Fatal("expected error for short extradata")
 	}
-}
-
-func TestGetLastBlockByBatchIdStartsFromHeadL1Origin(t *testing.T) {
-	key, err := crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
-	if err != nil {
-		t.Fatalf("failed to load key: %v", err)
-	}
-	addr := crypto.PubkeyToAddress(key.PublicKey)
-
-	genesis := &core.Genesis{
-		Config: params.AllEthashProtocolChanges,
-		Alloc: types.GenesisAlloc{
-			addr: {Balance: new(big.Int).SetUint64(1_000_000_000_000_000_000)},
-		},
-	}
-	engine := ethash.NewFaker()
-
-	anchorData := append([]byte{}, taiko.AnchorV4Selector...)
-	anchorData = append(anchorData, 0x01)
-
-	db, blocks, _ := core.GenerateChainWithGenesis(genesis, engine, 4, func(i int, b *core.BlockGen) {
-		b.SetExtra(shastaExtraData(uint64(i + 1)))
-		tx := types.MustSignNewTx(key, b.Signer(), &types.LegacyTx{
-			Nonce:    b.TxNonce(addr),
-			To:       &common.Address{},
-			Gas:      100000,
-			GasPrice: new(big.Int).SetUint64(params.InitialBaseFee * 2),
-			Data:     anchorData,
-		})
-		b.AddTx(tx)
-	})
-
-	chain, err := core.NewBlockChain(db, nil, genesis, nil, engine, vm.Config{}, nil)
-	if err != nil {
-		t.Fatalf("failed to create blockchain: %v", err)
-	}
-	if _, err := chain.InsertChain(blocks); err != nil {
-		t.Fatalf("failed to insert chain: %v", err)
-	}
-	defer chain.Stop()
-
-	headBlockID := big.NewInt(2)
-	rawdb.WriteL1Origin(db, headBlockID, &rawdb.L1Origin{
-		BlockID:     headBlockID,
-		L2BlockHash: blocks[1].Hash(),
-	})
-	rawdb.WriteHeadL1Origin(db, headBlockID)
-
-	backend := NewTaikoAPIBackend(&Ethereum{
-		blockchain: chain,
-		chainDb:    db,
-	})
-
-	blockID, err := backend.getLastBlockByBatchId(big.NewInt(4))
-	if err != ethereum.NotFound {
-		t.Fatalf("expected not found error, got %v", err)
-	}
-	if blockID != nil {
-		t.Fatalf("expected nil block ID, got %v", blockID)
-	}
-}
-
-func shastaExtraData(proposalID uint64) []byte {
-	extra := make([]byte, params.ShastaExtraDataLen)
-	encoded := new(big.Int).SetUint64(proposalID).Bytes()
-	buf := make([]byte, params.ShastaExtraDataProposalIDLength)
-	copy(buf[len(buf)-len(encoded):], encoded)
-	copy(extra[params.ShastaExtraDataProposalIDIndex:], buf)
-	return extra
 }

--- a/eth/taiko_api_backend_test.go
+++ b/eth/taiko_api_backend_test.go
@@ -1,10 +1,18 @@
 package eth
 
 import (
+	"errors"
 	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/consensus/taiko"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 func TestShastaProposalIDFromExtraData(t *testing.T) {
@@ -32,5 +40,55 @@ func TestShastaBasefeeSharingPctgFromExtraData(t *testing.T) {
 func TestShastaProposalIDFromExtraDataInvalid(t *testing.T) {
 	if _, err := core.DecodeShastaProposalID([]byte{0x01}); err == nil {
 		t.Fatal("expected error for short extradata")
+	}
+}
+
+func TestGetLastBlockByBatchIdUncertainAtHead(t *testing.T) {
+	proposalBytes := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}
+	proposalID := new(big.Int).SetBytes(proposalBytes)
+	extra := append([]byte{0x00}, proposalBytes...)
+	data := make([]byte, len(taiko.AnchorV4Selector))
+	copy(data, taiko.AnchorV4Selector)
+
+	genesis := &core.Genesis{
+		Config: params.TestChainConfig,
+		Alloc: types.GenesisAlloc{
+			testAddr: {Balance: big.NewInt(1_000_000_000_000_000_000)},
+		},
+	}
+	engine := ethash.NewFaker()
+
+	_, blocks, _ := core.GenerateChainWithGenesis(genesis, engine, 1, func(i int, b *core.BlockGen) {
+		b.SetExtra(extra)
+		tx := types.NewTx(&types.LegacyTx{
+			Nonce:    0,
+			To:       &common.Address{1},
+			Value:    big.NewInt(0),
+			Gas:      50_000,
+			GasPrice: b.BaseFee(),
+			Data:     data,
+		})
+		signed, err := types.SignTx(tx, types.HomesteadSigner{}, testKey)
+		if err != nil {
+			t.Fatalf("failed to sign tx: %v", err)
+		}
+		b.AddTx(signed)
+	})
+
+	chain, err := core.NewBlockChain(rawdb.NewMemoryDatabase(), nil, genesis, nil, engine, vm.Config{}, nil)
+	if err != nil {
+		t.Fatalf("failed to create chain: %v", err)
+	}
+	if _, err := chain.InsertChain(blocks); err != nil {
+		t.Fatalf("failed to insert chain: %v", err)
+	}
+
+	backend := &TaikoAPIBackend{eth: &Ethereum{blockchain: chain}}
+	blockID, err := backend.getLastBlockByBatchId(proposalID)
+	if !errors.Is(err, ErrProposalLastBlockUncertain) {
+		t.Fatalf("expected ErrProposalLastBlockUncertain, got %v", err)
+	}
+	if blockID != nil {
+		t.Fatalf("expected nil blockID, got %v", blockID)
 	}
 }

--- a/eth/taiko_api_backend_test.go
+++ b/eth/taiko_api_backend_test.go
@@ -1,24 +1,15 @@
 package eth
 
 import (
-	"errors"
 	"math/big"
 	"testing"
 
-	"github.com/ethereum/go-ethereum"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/math"
-	"github.com/ethereum/go-ethereum/consensus/ethash"
-	"github.com/ethereum/go-ethereum/consensus/taiko"
 	"github.com/ethereum/go-ethereum/core"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/core/vm"
-	"github.com/ethereum/go-ethereum/params"
 )
 
 func TestShastaProposalIDFromExtraData(t *testing.T) {
-	extra := []byte{0x2a, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x01}
-	proposalID, endOfProposal, err := core.DecodeShastaProposalID(extra)
+	extra := []byte{0x2a, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06}
+	proposalID, err := core.DecodeShastaProposalID(extra)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -26,13 +17,10 @@ func TestShastaProposalIDFromExtraData(t *testing.T) {
 	if proposalID.Cmp(expected) != 0 {
 		t.Fatalf("expected %s, got %s", expected.String(), proposalID.String())
 	}
-	if !endOfProposal {
-		t.Fatal("expected endOfProposal to be true")
-	}
 }
 
 func TestShastaBasefeeSharingPctgFromExtraData(t *testing.T) {
-	extra := []byte{0x64, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+	extra := []byte{0x64, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
 	if pctg := core.DecodeShastaBasefeeSharingPctg(extra); pctg != 0x64 {
 		t.Fatalf("expected 0x64, got %d", pctg)
 	}
@@ -42,87 +30,7 @@ func TestShastaBasefeeSharingPctgFromExtraData(t *testing.T) {
 }
 
 func TestShastaProposalIDFromExtraDataInvalid(t *testing.T) {
-	tests := []struct {
-		name  string
-		extra []byte
-	}{
-		{
-			name:  "short",
-			extra: []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07},
-		},
-		{
-			name:  "long",
-			extra: []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09},
-		},
+	if _, err := core.DecodeShastaProposalID([]byte{0x01}); err == nil {
+		t.Fatal("expected error for short extradata")
 	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			if _, _, err := core.DecodeShastaProposalID(test.extra); err == nil {
-				t.Fatal("expected error for invalid extradata length")
-			}
-		})
-	}
-}
-
-func TestLastBlockIDByBatchIDRequiresEndOfProposal(t *testing.T) {
-	extra := []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00}
-	chain := newShastaTestChain(t, extra)
-	defer chain.Stop()
-	backend := &TaikoAPIBackend{eth: &Ethereum{blockchain: chain}}
-	if _, err := backend.LastBlockIDByBatchID((*math.HexOrDecimal256)(big.NewInt(1))); err == nil {
-		t.Fatal("expected error when endOfProposal is false")
-	}
-}
-
-func TestLastBlockIDByBatchIDTooLarge(t *testing.T) {
-	extra := []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01}
-	chain := newShastaTestChain(t, extra)
-	defer chain.Stop()
-
-	backend := &TaikoAPIBackend{eth: &Ethereum{blockchain: chain}}
-	if _, err := backend.LastBlockIDByBatchID((*math.HexOrDecimal256)(big.NewInt(2))); err == nil {
-		t.Fatal("expected error when batchID is greater than head proposalID")
-	} else if errors.Is(err, ethereum.NotFound) {
-		t.Fatal("expected direct error, got NotFound")
-	}
-}
-
-func newShastaTestChain(t *testing.T, extra []byte) *core.BlockChain {
-	t.Helper()
-
-	genesis := &core.Genesis{
-		Config: params.TestChainConfig,
-		Alloc: types.GenesisAlloc{
-			testAddr: {Balance: big.NewInt(1_000_000_000_000_000_000)},
-		},
-		BaseFee: big.NewInt(params.InitialBaseFee),
-	}
-
-	db, blocks, _ := core.GenerateChainWithGenesis(genesis, ethash.NewFaker(), 1, func(i int, gen *core.BlockGen) {
-		gen.SetExtra(extra)
-		data := append(append([]byte{}, taiko.AnchorV4Selector...), 0x00)
-		tx := types.NewTransaction(
-			gen.TxNonce(testAddr),
-			common.Address{},
-			big.NewInt(0),
-			100000,
-			big.NewInt(params.InitialBaseFee*2),
-			data,
-		)
-		signedTx, err := types.SignTx(tx, gen.Signer(), testKey)
-		if err != nil {
-			panic(err)
-		}
-		gen.AddTx(signedTx)
-	})
-
-	chain, err := core.NewBlockChain(db, nil, genesis, nil, ethash.NewFaker(), vm.Config{}, nil)
-	if err != nil {
-		t.Fatalf("failed to create blockchain: %v", err)
-	}
-	if _, err := chain.InsertChain(blocks); err != nil {
-		t.Fatalf("failed to insert chain: %v", err)
-	}
-	return chain
 }

--- a/eth/taiko_api_backend_test.go
+++ b/eth/taiko_api_backend_test.go
@@ -72,8 +72,6 @@ func TestLastBlockIDByBatchIDRequiresEndOfProposal(t *testing.T) {
 	backend := &TaikoAPIBackend{eth: &Ethereum{blockchain: chain}}
 	if _, err := backend.LastBlockIDByBatchID((*math.HexOrDecimal256)(big.NewInt(1))); err == nil {
 		t.Fatal("expected error when endOfProposal is false")
-	} else if !errors.Is(err, ethereum.NotFound) {
-		t.Fatalf("expected NotFound, got %v", err)
 	}
 }
 
@@ -85,8 +83,8 @@ func TestLastBlockIDByBatchIDTooLarge(t *testing.T) {
 	backend := &TaikoAPIBackend{eth: &Ethereum{blockchain: chain}}
 	if _, err := backend.LastBlockIDByBatchID((*math.HexOrDecimal256)(big.NewInt(2))); err == nil {
 		t.Fatal("expected error when batchID is greater than head proposalID")
-	} else if !errors.Is(err, ethereum.NotFound) {
-		t.Fatalf("expected NotFound, got %v", err)
+	} else if errors.Is(err, ethereum.NotFound) {
+		t.Fatal("expected direct error, got NotFound")
 	}
 }
 

--- a/eth/taiko_api_backend_test.go
+++ b/eth/taiko_api_backend_test.go
@@ -4,7 +4,16 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/consensus/taiko"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 func TestShastaProposalIDFromExtraData(t *testing.T) {
@@ -33,4 +42,73 @@ func TestShastaProposalIDFromExtraDataInvalid(t *testing.T) {
 	if _, err := core.DecodeShastaProposalID([]byte{0x01}); err == nil {
 		t.Fatal("expected error for short extradata")
 	}
+}
+
+func TestGetLastBlockByBatchIdStartsFromHeadL1Origin(t *testing.T) {
+	key, err := crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+	if err != nil {
+		t.Fatalf("failed to load key: %v", err)
+	}
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+
+	genesis := &core.Genesis{
+		Config: params.AllEthashProtocolChanges,
+		Alloc: types.GenesisAlloc{
+			addr: {Balance: new(big.Int).SetUint64(1_000_000_000_000_000_000)},
+		},
+	}
+	engine := ethash.NewFaker()
+
+	anchorData := append([]byte{}, taiko.AnchorV4Selector...)
+	anchorData = append(anchorData, 0x01)
+
+	db, blocks, _ := core.GenerateChainWithGenesis(genesis, engine, 4, func(i int, b *core.BlockGen) {
+		b.SetExtra(shastaExtraData(uint64(i + 1)))
+		tx := types.MustSignNewTx(key, b.Signer(), &types.LegacyTx{
+			Nonce:    b.TxNonce(addr),
+			To:       &common.Address{},
+			Gas:      100000,
+			GasPrice: new(big.Int).SetUint64(params.InitialBaseFee * 2),
+			Data:     anchorData,
+		})
+		b.AddTx(tx)
+	})
+
+	chain, err := core.NewBlockChain(db, nil, genesis, nil, engine, vm.Config{}, nil)
+	if err != nil {
+		t.Fatalf("failed to create blockchain: %v", err)
+	}
+	if _, err := chain.InsertChain(blocks); err != nil {
+		t.Fatalf("failed to insert chain: %v", err)
+	}
+	defer chain.Stop()
+
+	headBlockID := big.NewInt(2)
+	rawdb.WriteL1Origin(db, headBlockID, &rawdb.L1Origin{
+		BlockID:     headBlockID,
+		L2BlockHash: blocks[1].Hash(),
+	})
+	rawdb.WriteHeadL1Origin(db, headBlockID)
+
+	backend := NewTaikoAPIBackend(&Ethereum{
+		blockchain: chain,
+		chainDb:    db,
+	})
+
+	blockID, err := backend.getLastBlockByBatchId(big.NewInt(4))
+	if err != ethereum.NotFound {
+		t.Fatalf("expected not found error, got %v", err)
+	}
+	if blockID != nil {
+		t.Fatalf("expected nil block ID, got %v", blockID)
+	}
+}
+
+func shastaExtraData(proposalID uint64) []byte {
+	extra := make([]byte, params.ShastaExtraDataLen)
+	encoded := new(big.Int).SetUint64(proposalID).Bytes()
+	buf := make([]byte, params.ShastaExtraDataProposalIDLength)
+	copy(buf[len(buf)-len(encoded):], encoded)
+	copy(extra[params.ShastaExtraDataProposalIDIndex:], buf)
+	return extra
 }

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -137,8 +137,7 @@ const (
 	ShastaExtraDataBasefeeSharingPctgIndex = 0
 	ShastaExtraDataProposalIDIndex         = 1
 	ShastaExtraDataProposalIDLength        = 6
-	ShastaExtraDataEndOfProposalIndex      = 7
-	ShastaExtraDataLen                     = 8
+	ShastaExtraDataLen                     = 1 + ShastaExtraDataProposalIDLength
 
 	MaxCodeSize     = 24576           // Maximum bytecode to permit for a contract
 	MaxInitCodeSize = 2 * MaxCodeSize // Maximum initcode to permit in a creation transaction and create instructions


### PR DESCRIPTION
  ## Summary
  - Revert #500/#502: drop Shasta EOP flag, restore batch-to-last-block mapping (rawdb + forkchoiceUpdated + RPC setter), and relax Shasta extra-data length checks.
 - `LastBlockIDByBatchID` prefers `BatchToLastBlockID` mapping and falls back to anchor scan; head match without mapping returns `ErrProposalLastBlockUncertain`.

For reviewing, can just check diffs in https://github.com/taikoxyz/taiko-geth/pull/504/commits/b6924ffa0e269b6ab5e836c450dec21b46d54930 .