### PR TITLE
fix(consensus): skip EIP-4396 check when ancestor is missing

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: "Push multi-arch docker image to GAR"
 
 on:
   push:
-    branches: [taiko, update-verifyHeader]
+    branches: [taiko]
     tags:
       - "v*"
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: "Push multi-arch docker image to GAR"
 
 on:
   push:
-    branches: [taiko]
+    branches: [taiko, update-verifyHeader]
     tags:
       - "v*"
 

--- a/consensus/taiko/consensus.go
+++ b/consensus/taiko/consensus.go
@@ -200,7 +200,6 @@ func (t *Taiko) verifyHeader(chain consensus.ChainHeaderReader, header, parent *
 				)
 			}
 		}
-
 	}
 
 	// WithdrawalsHash should not be empty

--- a/consensus/taiko/consensus.go
+++ b/consensus/taiko/consensus.go
@@ -187,17 +187,20 @@ func (t *Taiko) verifyHeader(chain consensus.ChainHeaderReader, header, parent *
 		if len(header.Extra) < params.ShastaExtraDataLen {
 			return fmt.Errorf("Shasta extra-data too short: %d < %d", len(header.Extra), params.ShastaExtraDataLen)
 		}
-		var parentBlockTime uint64
 		if header.Number.Cmp(common.Big1) > 0 {
 			if ancestorBlock := chain.GetHeader(parent.ParentHash, parent.Number.Uint64()-1); ancestorBlock != nil {
-				parentBlockTime = parent.Time - ancestorBlock.Time
+				if err := misc.VerifyEIP4396Header(t.chainConfig, parent, parent.Time-ancestorBlock.Time, header); err != nil {
+					return err
+				}
 			} else {
-				return fmt.Errorf("ancestor block not found for parent %s", parent.ParentHash.Hex())
+				log.Warn(
+					"Skipping EIP-4396 verification due to unknown ancestor",
+					"parent", parent.Hash(),
+					"number", parent.Number,
+				)
 			}
 		}
-		if err := misc.VerifyEIP4396Header(t.chainConfig, parent, parentBlockTime, header); err != nil {
-			return err
-		}
+
 	}
 
 	// WithdrawalsHash should not be empty

--- a/consensus/taiko/consensus.go
+++ b/consensus/taiko/consensus.go
@@ -187,7 +187,6 @@ func (t *Taiko) verifyHeader(chain consensus.ChainHeaderReader, header, parent *
 		if len(header.Extra) < params.ShastaExtraDataLen {
 			return fmt.Errorf("Shasta extra-data too short: %d < %d", len(header.Extra), params.ShastaExtraDataLen)
 		}
-
 		if header.Number.Cmp(common.Big1) > 0 {
 			if ancestorBlock := chain.GetHeader(parent.ParentHash, parent.Number.Uint64()-1); ancestorBlock != nil {
 				if err := misc.VerifyEIP4396Header(t.chainConfig, parent, parent.Time-ancestorBlock.Time, header); err != nil {

--- a/consensus/taiko/consensus.go
+++ b/consensus/taiko/consensus.go
@@ -187,6 +187,7 @@ func (t *Taiko) verifyHeader(chain consensus.ChainHeaderReader, header, parent *
 		if len(header.Extra) < params.ShastaExtraDataLen {
 			return fmt.Errorf("Shasta extra-data too short: %d < %d", len(header.Extra), params.ShastaExtraDataLen)
 		}
+
 		if header.Number.Cmp(common.Big1) > 0 {
 			if ancestorBlock := chain.GetHeader(parent.ParentHash, parent.Number.Uint64()-1); ancestorBlock != nil {
 				if err := misc.VerifyEIP4396Header(t.chainConfig, parent, parent.Time-ancestorBlock.Time, header); err != nil {


### PR DESCRIPTION
  ## Summary 
Avoid failing Taiko header verification when the parent’s ancestor is unavailable by skipping EIP-4396 validation and logging a warning (usually happening during beacon-sync, based on the feedback from CB). This situation can occur during beacon sync.
  ##  Changes 
In consensus/taiko/consensus.go, only run VerifyEIP4396Header when the ancestor is present; otherwise emit a warning and continue.