### PR TITLE
feat(rpc): move last block in proposal lookup RPCs to `taikoAuth`

### DIFF
--- a/eth/taiko_api_backend.go
+++ b/eth/taiko_api_backend.go
@@ -84,13 +84,54 @@ func (s *TaikoAPIBackend) GetSyncMode() (string, error) {
 // when searching for the last block of a given batch ID.
 const maxBatchLookupBlocks = 192 * 1024
 
+// TaikoAuthAPIBackend handles L2 node related authorized RPC calls.
+type TaikoAuthAPIBackend struct {
+	eth *Ethereum
+}
+
+// NewTaikoAuthAPIBackend creates a new TaikoAuthAPIBackend instance.
+func NewTaikoAuthAPIBackend(eth *Ethereum) *TaikoAuthAPIBackend {
+	return &TaikoAuthAPIBackend{eth}
+}
+
+// LastL1OriginByBatchID returns the L1 origin of the last block for the given batch.
+func (a *TaikoAuthAPIBackend) LastL1OriginByBatchID(batchID *math.HexOrDecimal256) (*rawdb.L1Origin, error) {
+	blockID, err := rawdb.ReadBatchToLastBlockID(a.eth.ChainDb(), (*big.Int)(batchID))
+	if err != nil && !errors.Is(err, ethereum.NotFound) {
+		return nil, err
+	}
+	if blockID == nil {
+		if blockID, err = a.getLastBlockByBatchId((*big.Int)(batchID)); err != nil {
+			return nil, err
+		}
+		if blockID == nil {
+			return nil, ethereum.NotFound
+		}
+	}
+
+	return rawdb.ReadL1Origin(a.eth.ChainDb(), (*big.Int)(blockID))
+}
+
+// LastBlockIDByBatchID returns the ID of the last block for the given batch.
+func (a *TaikoAuthAPIBackend) LastBlockIDByBatchID(batchID *math.HexOrDecimal256) (*hexutil.Big, error) {
+	blockID, err := rawdb.ReadBatchToLastBlockID(a.eth.ChainDb(), (*big.Int)(batchID))
+	if err != nil && !errors.Is(err, ethereum.NotFound) {
+		return nil, err
+	}
+	if blockID != nil {
+		return blockID, nil
+	}
+
+	return a.getLastBlockByBatchId((*big.Int)(batchID))
+}
+
 // getLastBlockByBatchId traverses the blockchain backwards to find the last Shasta block of the given Shasta batch ID.
-func (s *TaikoAPIBackend) getLastBlockByBatchId(batchID *big.Int) (*hexutil.Big, error) {
+func (a *TaikoAuthAPIBackend) getLastBlockByBatchId(batchID *big.Int) (*hexutil.Big, error) {
 	// We start from the head L1 origin and traverse backwards until we find
 	// the matching batch ID, to ignore all preconfirmation blocks at the chain tip.
 	var (
-		headNumber   = s.eth.BlockChain().CurrentHeader().Number
-		currentBlock = s.eth.BlockChain().GetBlockByNumber(headNumber.Uint64())
+		headNumber   = a.eth.BlockChain().CurrentHeader().Number
+		currentBlock = a.eth.BlockChain().GetBlockByNumber(headNumber.Uint64())
 		lookedBack   uint64
 	)
 
@@ -104,13 +145,13 @@ func (s *TaikoAPIBackend) getLastBlockByBatchId(batchID *big.Int) (*hexutil.Big,
 		if currentBlock.NumberU64() == 0 {
 			break
 		}
-		l1Origin, err := rawdb.ReadL1Origin(s.eth.ChainDb(), currentBlock.Number())
+		l1Origin, err := rawdb.ReadL1Origin(a.eth.ChainDb(), currentBlock.Number())
 		if err != nil && !errors.Is(err, ethereum.NotFound) {
 			return nil, err
 		}
 		// Skip preconfirmation blocks.
 		if l1Origin != nil && l1Origin.IsPreconfBlock() {
-			currentBlock = s.eth.BlockChain().GetBlockByNumber(currentBlock.NumberU64() - 1)
+			currentBlock = a.eth.BlockChain().GetBlockByNumber(currentBlock.NumberU64() - 1)
 			continue
 		}
 
@@ -126,51 +167,9 @@ func (s *TaikoAPIBackend) getLastBlockByBatchId(batchID *big.Int) (*hexutil.Big,
 			return (*hexutil.Big)(currentBlock.Number()), nil
 		}
 
-		currentBlock = s.eth.BlockChain().GetBlockByNumber(currentBlock.NumberU64() - 1)
+		currentBlock = a.eth.BlockChain().GetBlockByNumber(currentBlock.NumberU64() - 1)
 	}
 	return nil, ethereum.NotFound
-}
-
-// TaikoAuthAPIBackend handles L2 node related authorized RPC calls.
-type TaikoAuthAPIBackend struct {
-	eth *Ethereum
-}
-
-// NewTaikoAuthAPIBackend creates a new TaikoAuthAPIBackend instance.
-func NewTaikoAuthAPIBackend(eth *Ethereum) *TaikoAuthAPIBackend {
-	return &TaikoAuthAPIBackend{eth}
-}
-
-// LastL1OriginByBatchID returns the L1 origin of the last block for the given batch.
-func (a *TaikoAuthAPIBackend) LastL1OriginByBatchID(batchID *math.HexOrDecimal256) (*rawdb.L1Origin, error) {
-	apiBackend := &TaikoAPIBackend{eth: a.eth}
-	blockID, err := rawdb.ReadBatchToLastBlockID(a.eth.ChainDb(), (*big.Int)(batchID))
-	if err != nil && !errors.Is(err, ethereum.NotFound) {
-		return nil, err
-	}
-	if blockID == nil {
-		if blockID, err = apiBackend.getLastBlockByBatchId((*big.Int)(batchID)); err != nil {
-			return nil, err
-		}
-		if blockID == nil {
-			return nil, ethereum.NotFound
-		}
-	}
-	return apiBackend.L1OriginByID((*math.HexOrDecimal256)(blockID))
-}
-
-// LastBlockIDByBatchID returns the ID of the last block for the given batch.
-func (a *TaikoAuthAPIBackend) LastBlockIDByBatchID(batchID *math.HexOrDecimal256) (*hexutil.Big, error) {
-	apiBackend := &TaikoAPIBackend{eth: a.eth}
-	blockID, err := rawdb.ReadBatchToLastBlockID(a.eth.ChainDb(), (*big.Int)(batchID))
-	if err != nil && !errors.Is(err, ethereum.NotFound) {
-		return nil, err
-	}
-	if blockID != nil {
-		return blockID, nil
-	}
-
-	return apiBackend.getLastBlockByBatchId((*big.Int)(batchID))
 }
 
 // SetHeadL1Origin sets the latest L2 block's corresponding L1 origin.

--- a/eth/taiko_api_backend.go
+++ b/eth/taiko_api_backend.go
@@ -75,36 +75,6 @@ func (s *TaikoAPIBackend) L1OriginByID(blockID *math.HexOrDecimal256) (*rawdb.L1
 	return l1Origin, nil
 }
 
-// LastL1OriginByBatchID returns the L1 origin of the last block for the given batch.
-func (s *TaikoAPIBackend) LastL1OriginByBatchID(batchID *math.HexOrDecimal256) (*rawdb.L1Origin, error) {
-	blockID, err := rawdb.ReadBatchToLastBlockID(s.eth.ChainDb(), (*big.Int)(batchID))
-	if err != nil && !errors.Is(err, ethereum.NotFound) {
-		return nil, err
-	}
-	if blockID == nil {
-		if blockID, err = s.getLastBlockByBatchId((*big.Int)(batchID)); err != nil {
-			return nil, err
-		}
-		if blockID == nil {
-			return nil, ethereum.NotFound
-		}
-	}
-	return s.L1OriginByID((*math.HexOrDecimal256)(blockID))
-}
-
-// LastBlockIDByBatchID returns the ID of the last block for the given batch.
-func (s *TaikoAPIBackend) LastBlockIDByBatchID(batchID *math.HexOrDecimal256) (*hexutil.Big, error) {
-	blockID, err := rawdb.ReadBatchToLastBlockID(s.eth.ChainDb(), (*big.Int)(batchID))
-	if err != nil && !errors.Is(err, ethereum.NotFound) {
-		return nil, err
-	}
-	if blockID != nil {
-		return blockID, nil
-	}
-
-	return s.getLastBlockByBatchId((*big.Int)(batchID))
-}
-
 // GetSyncMode returns the node sync mode.
 func (s *TaikoAPIBackend) GetSyncMode() (string, error) {
 	return s.eth.config.SyncMode.String(), nil
@@ -175,7 +145,7 @@ func NewTaikoAuthAPIBackend(eth *Ethereum) *TaikoAuthAPIBackend {
 func (a *TaikoAuthAPIBackend) LastL1OriginByBatchID(batchID *math.HexOrDecimal256) (*rawdb.L1Origin, error) {
 	apiBackend := &TaikoAPIBackend{eth: a.eth}
 	blockID, err := rawdb.ReadBatchToLastBlockID(a.eth.ChainDb(), (*big.Int)(batchID))
-	if err != nil {
+	if err != nil && !errors.Is(err, ethereum.NotFound) {
 		return nil, err
 	}
 	if blockID == nil {
@@ -193,7 +163,7 @@ func (a *TaikoAuthAPIBackend) LastL1OriginByBatchID(batchID *math.HexOrDecimal25
 func (a *TaikoAuthAPIBackend) LastBlockIDByBatchID(batchID *math.HexOrDecimal256) (*hexutil.Big, error) {
 	apiBackend := &TaikoAPIBackend{eth: a.eth}
 	blockID, err := rawdb.ReadBatchToLastBlockID(a.eth.ChainDb(), (*big.Int)(batchID))
-	if err != nil {
+	if err != nil && !errors.Is(err, ethereum.NotFound) {
 		return nil, err
 	}
 	if blockID != nil {

--- a/eth/taiko_api_backend.go
+++ b/eth/taiko_api_backend.go
@@ -75,36 +75,6 @@ func (s *TaikoAPIBackend) L1OriginByID(blockID *math.HexOrDecimal256) (*rawdb.L1
 	return l1Origin, nil
 }
 
-// LastL1OriginByBatchID returns the L1 origin of the last block for the given batch.
-func (s *TaikoAPIBackend) LastL1OriginByBatchID(batchID *math.HexOrDecimal256) (*rawdb.L1Origin, error) {
-	blockID, err := rawdb.ReadBatchToLastBlockID(s.eth.ChainDb(), (*big.Int)(batchID))
-	if err != nil {
-		return nil, err
-	}
-	if blockID == nil {
-		if blockID, err = s.getLastBlockByBatchId((*big.Int)(batchID)); err != nil {
-			return nil, err
-		}
-		if blockID == nil {
-			return nil, ethereum.NotFound
-		}
-	}
-	return s.L1OriginByID((*math.HexOrDecimal256)(blockID))
-}
-
-// LastBlockIDByBatchID returns the ID of the last block for the given batch.
-func (s *TaikoAPIBackend) LastBlockIDByBatchID(batchID *math.HexOrDecimal256) (*hexutil.Big, error) {
-	blockID, err := rawdb.ReadBatchToLastBlockID(s.eth.ChainDb(), (*big.Int)(batchID))
-	if err != nil {
-		return nil, err
-	}
-	if blockID != nil {
-		return blockID, nil
-	}
-
-	return s.getLastBlockByBatchId((*big.Int)(batchID))
-}
-
 // GetSyncMode returns the node sync mode.
 func (s *TaikoAPIBackend) GetSyncMode() (string, error) {
 	return s.eth.config.SyncMode.String(), nil
@@ -164,6 +134,38 @@ type TaikoAuthAPIBackend struct {
 // NewTaikoAuthAPIBackend creates a new TaikoAuthAPIBackend instance.
 func NewTaikoAuthAPIBackend(eth *Ethereum) *TaikoAuthAPIBackend {
 	return &TaikoAuthAPIBackend{eth}
+}
+
+// LastL1OriginByBatchID returns the L1 origin of the last block for the given batch.
+func (a *TaikoAuthAPIBackend) LastL1OriginByBatchID(batchID *math.HexOrDecimal256) (*rawdb.L1Origin, error) {
+	apiBackend := &TaikoAPIBackend{eth: a.eth}
+	blockID, err := rawdb.ReadBatchToLastBlockID(a.eth.ChainDb(), (*big.Int)(batchID))
+	if err != nil {
+		return nil, err
+	}
+	if blockID == nil {
+		if blockID, err = apiBackend.getLastBlockByBatchId((*big.Int)(batchID)); err != nil {
+			return nil, err
+		}
+		if blockID == nil {
+			return nil, ethereum.NotFound
+		}
+	}
+	return apiBackend.L1OriginByID((*math.HexOrDecimal256)(blockID))
+}
+
+// LastBlockIDByBatchID returns the ID of the last block for the given batch.
+func (a *TaikoAuthAPIBackend) LastBlockIDByBatchID(batchID *math.HexOrDecimal256) (*hexutil.Big, error) {
+	apiBackend := &TaikoAPIBackend{eth: a.eth}
+	blockID, err := rawdb.ReadBatchToLastBlockID(a.eth.ChainDb(), (*big.Int)(batchID))
+	if err != nil {
+		return nil, err
+	}
+	if blockID != nil {
+		return blockID, nil
+	}
+
+	return apiBackend.getLastBlockByBatchId((*big.Int)(batchID))
 }
 
 // SetHeadL1Origin sets the latest L2 block's corresponding L1 origin.

--- a/eth/taiko_api_backend_test.go
+++ b/eth/taiko_api_backend_test.go
@@ -3,6 +3,7 @@ package eth
 import (
 	"errors"
 	"math/big"
+	"reflect"
 	"testing"
 
 	"github.com/ethereum/go-ethereum"
@@ -42,6 +43,24 @@ func TestShastaBasefeeSharingPctgFromExtraData(t *testing.T) {
 func TestShastaProposalIDFromExtraDataInvalid(t *testing.T) {
 	if _, err := core.DecodeShastaProposalID([]byte{0x01}); err == nil {
 		t.Fatal("expected error for short extradata")
+	}
+}
+
+func TestTaikoAuthBackendExposesBatchLookupMethods(t *testing.T) {
+	backendType := reflect.TypeOf(&TaikoAuthAPIBackend{})
+	for _, name := range []string{"LastL1OriginByBatchID", "LastBlockIDByBatchID"} {
+		if _, ok := backendType.MethodByName(name); !ok {
+			t.Fatalf("expected TaikoAuthAPIBackend to expose %s", name)
+		}
+	}
+}
+
+func TestTaikoAPIBackendHidesBatchLookupMethods(t *testing.T) {
+	backendType := reflect.TypeOf(&TaikoAPIBackend{})
+	for _, name := range []string{"LastL1OriginByBatchID", "LastBlockIDByBatchID"} {
+		if _, ok := backendType.MethodByName(name); ok {
+			t.Fatalf("expected TaikoAPIBackend to hide %s", name)
+		}
 	}
 }
 

--- a/eth/taiko_api_backend_test.go
+++ b/eth/taiko_api_backend_test.go
@@ -65,7 +65,7 @@ func TestTaikoAPIBackendHidesBatchLookupMethods(t *testing.T) {
 
 func TestGetLastBlockByBatchIdNoHeadL1Origin(t *testing.T) {
 	db, chain, proposalID, _ := newShastaTestChain(t)
-	backend := &TaikoAPIBackend{eth: &Ethereum{blockchain: chain, chainDb: db}}
+	backend := &TaikoAuthAPIBackend{eth: &Ethereum{blockchain: chain, chainDb: db}}
 
 	blockID, err := backend.getLastBlockByBatchId(proposalID)
 	if !errors.Is(err, ErrProposalLastBlockUncertain) {
@@ -78,7 +78,7 @@ func TestGetLastBlockByBatchIdNoHeadL1Origin(t *testing.T) {
 
 func TestGetLastBlockByBatchIdUncertainAtHead(t *testing.T) {
 	db, chain, proposalID, blocks := newShastaTestChain(t)
-	backend := &TaikoAPIBackend{eth: &Ethereum{blockchain: chain, chainDb: db}}
+	backend := &TaikoAuthAPIBackend{eth: &Ethereum{blockchain: chain, chainDb: db}}
 	headBlock := blocks[len(blocks)-1]
 	rawdb.WriteL1Origin(db, headBlock.Number(), &rawdb.L1Origin{
 		BlockID:       headBlock.Number(),
@@ -162,7 +162,7 @@ func TestGetLastBlockByBatchIdLookbackLimit(t *testing.T) {
 		t.Fatal("failed to build test chain")
 	}
 
-	backend := &TaikoAPIBackend{eth: &Ethereum{blockchain: chain, chainDb: db}}
+	backend := &TaikoAuthAPIBackend{eth: &Ethereum{blockchain: chain, chainDb: db}}
 	rawdb.WriteL1Origin(db, headBlock.Number(), &rawdb.L1Origin{
 		BlockID:       headBlock.Number(),
 		L2BlockHash:   headBlock.Hash(),

--- a/ethclient/taiko_api.go
+++ b/ethclient/taiko_api.go
@@ -34,7 +34,7 @@ func (ec *Client) L1OriginByID(ctx context.Context, blockID *big.Int) (*rawdb.L1
 func (ec *Client) LastL1OriginByBatchID(ctx context.Context, batchID *big.Int) (*rawdb.L1Origin, error) {
 	var res *rawdb.L1Origin
 
-	if err := ec.c.CallContext(ctx, &res, "taiko_lastL1OriginByBatchID", hexutil.EncodeBig(batchID)); err != nil {
+	if err := ec.c.CallContext(ctx, &res, "taikoAuth_lastL1OriginByBatchID", hexutil.EncodeBig(batchID)); err != nil {
 		return nil, err
 	}
 
@@ -45,7 +45,7 @@ func (ec *Client) LastL1OriginByBatchID(ctx context.Context, batchID *big.Int) (
 func (ec *Client) LastBlockIDByBatchID(ctx context.Context, batchID *big.Int) (*hexutil.Big, error) {
 	var res *hexutil.Big
 
-	if err := ec.c.CallContext(ctx, &res, "taiko_lastBlockIDByBatchID", hexutil.EncodeBig(batchID)); err != nil {
+	if err := ec.c.CallContext(ctx, &res, "taikoAuth_lastBlockIDByBatchID", hexutil.EncodeBig(batchID)); err != nil {
 		return nil, err
 	}
 

--- a/ethclient/taiko_api_test.go
+++ b/ethclient/taiko_api_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -86,6 +87,37 @@ func newTaikoAPITestClient(t *testing.T) (*Client, []*types.Block, ethdb.Databas
 	return NewClient(n.Attach()), blocks, ethservice.ChainDb()
 }
 
+func newTaikoAuthAPITestClient(t *testing.T) (*Client, []*types.Block, ethdb.Database) {
+	// Generate test chain.
+	genesis, blocks := generateTestChain()
+
+	// Create node
+	n, err := node.New(&node.Config{})
+	require.Nil(t, err)
+
+	// Create Ethereum Service
+	config := &ethconfig.Config{Genesis: genesis}
+	ethservice, err := eth.New(n, config)
+	require.Nil(t, err)
+
+	n.RegisterAPIs([]rpc.API{
+		{
+			Namespace:     "taikoAuth",
+			Service:       eth.NewTaikoAuthAPIBackend(ethservice),
+			Authenticated: true,
+		},
+	})
+
+	// Start node
+	require.Nil(t, n.Start())
+
+	// Insert test blocks
+	_, err = ethservice.BlockChain().InsertChain(blocks[1:])
+	require.Nil(t, err)
+
+	return NewClient(n.Attach()), blocks, ethservice.ChainDb()
+}
+
 func TestHeadL1Origin(t *testing.T) {
 	ec, blocks, db := newTaikoAPITestClient(t)
 
@@ -134,6 +166,38 @@ func TestL1OriginByID(t *testing.T) {
 
 	require.Nil(t, err)
 	require.Equal(t, testL1Origin, l1OriginFound)
+}
+
+func TestLastBlockIDByBatchID(t *testing.T) {
+	ec, blocks, db := newTaikoAuthAPITestClient(t)
+
+	batchID := big.NewInt(1)
+	blockID := blocks[len(blocks)-1].Number()
+
+	rawdb.WriteBatchToLastBlockID(db, batchID, blockID)
+
+	found, err := ec.LastBlockIDByBatchID(context.Background(), batchID)
+	require.Nil(t, err)
+	require.Equal(t, (*hexutil.Big)(blockID), found)
+}
+
+func TestLastL1OriginByBatchID(t *testing.T) {
+	ec, blocks, db := newTaikoAuthAPITestClient(t)
+
+	batchID := big.NewInt(1)
+	block := blocks[len(blocks)-1]
+
+	testL1Origin := &rawdb.L1Origin{
+		BlockID:     block.Number(),
+		L2BlockHash: block.Hash(),
+	}
+
+	rawdb.WriteBatchToLastBlockID(db, batchID, block.Number())
+	rawdb.WriteL1Origin(db, block.Number(), testL1Origin)
+
+	found, err := ec.LastL1OriginByBatchID(context.Background(), batchID)
+	require.Nil(t, err)
+	require.Equal(t, testL1Origin, found)
 }
 
 // randomHash generates a random blob of data and returns it as a hash.


### PR DESCRIPTION
 - Summary:
      - Move taiko_lastL1OriginByBatchID and taiko_lastBlockIDByBatchID from the public Taiko API to the authenticated taikoAuth_ namespace.
      - Update ethclient calls to use taikoAuth_lastL1OriginByBatchID and taikoAuth_lastBlockIDByBatchID.
      - Add tests to enforce auth-only exposure and verify client behavior.
  - Rationale:
      - These methods may scan a large number of blocks when the batch mapping is missing. Keeping them public increases risk of expensive queries. Restricting them to taikoAuth_ is safer and aligns with the intent of protected RPCs.
  - Breaking change / Migration:
      - Public RPC methods taiko_lastL1OriginByBatchID and taiko_lastBlockIDByBatchID are removed.
      - Callers must use the authenticated taikoAuth_ equivalents.