### PR TITLE
fix(consensus): refresh engine chain config after genesis config migration

### DIFF
--- a/consensus/taiko/consensus.go
+++ b/consensus/taiko/consensus.go
@@ -72,6 +72,21 @@ func New(chainConfig *params.ChainConfig, chainDB ethdb.Database) *Taiko {
 	}
 }
 
+// CHANGE(taiko): SetChainConfig updates chain config used by this engine and refreshes derived fields.
+func (t *Taiko) SetChainConfig(chainConfig *params.ChainConfig) {
+	if chainConfig == nil {
+		return
+	}
+	taikoL2AddressPrefix := strings.TrimPrefix(chainConfig.ChainID.String(), "0")
+	t.chainConfig = chainConfig
+	t.taikoL2Address = common.HexToAddress(
+		"0x" +
+			taikoL2AddressPrefix +
+			strings.Repeat("0", common.AddressLength*2-len(taikoL2AddressPrefix)-len(TaikoL2AddressSuffix)) +
+			TaikoL2AddressSuffix,
+	)
+}
+
 // check all method stubs for interface `Engine` without affect performance.
 var _ consensus.Engine = (*Taiko)(nil)
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -292,6 +292,10 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 	if err != nil {
 		return nil, err
 	}
+	// CHANGE(taiko): check the chain config.
+	if aware, ok := engine.(interface{ SetChainConfig(*params.ChainConfig) }); ok {
+		aware.SetChainConfig(chainConfig)
+	}
 	log.Info("")
 	log.Info(strings.Repeat("-", 153))
 	for _, line := range strings.Split(chainConfig.Description(), "\n") {

--- a/eth/taiko_fork_upgrade_test.go
+++ b/eth/taiko_fork_upgrade_test.go
@@ -1,0 +1,101 @@
+package eth
+
+import (
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/taiko"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/eth/ethconfig"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/triedb"
+)
+
+func TestShastaUpgradeUsesUpdatedChainConfigInConsensusEngine(t *testing.T) {
+	db := rawdb.NewMemoryDatabase()
+
+	// Simulate an old node database where ShastaTime is not present in chain config.
+	oldGenesis := core.TaikoGenesisBlock(params.TaikoHoodiNetworkID.Uint64())
+	oldCfg := *oldGenesis.Config
+	oldCfg.ShastaTime = nil
+	oldGenesis.Config = &oldCfg
+	oldGenesis.MustCommit(db, triedb.NewDatabase(db, triedb.HashDefaults))
+
+	// Simulate upgrade to a version that includes ShastaTime in Hoodi genesis config.
+	newGenesis := core.TaikoGenesisBlock(params.TaikoHoodiNetworkID.Uint64())
+	loadedCfg, err := core.LoadChainConfig(db, newGenesis)
+	if err != nil {
+		t.Fatalf("failed to load chain config: %v", err)
+	}
+	if loadedCfg.ShastaTime != nil {
+		t.Fatalf("expected old loaded config to have nil ShastaTime, got %d", *loadedCfg.ShastaTime)
+	}
+
+	engine, err := ethconfig.CreateConsensusEngine(loadedCfg, db)
+	if err != nil {
+		t.Fatalf("failed to create consensus engine: %v", err)
+	}
+	chain, err := core.NewBlockChain(db, nil, newGenesis, nil, engine, vm.Config{}, nil)
+	if err != nil {
+		t.Fatalf("failed to create blockchain: %v", err)
+	}
+	defer chain.Stop()
+
+	if chain.Config().ShastaTime == nil {
+		t.Fatal("expected blockchain config to contain ShastaTime after upgrade")
+	}
+	headerTime := *chain.Config().ShastaTime + 1
+
+	taikoEngine, ok := engine.(*taiko.Taiko)
+	if !ok {
+		t.Fatalf("expected taiko engine, got %T", engine)
+	}
+
+	to := taikoL2Address(chain.Config().ChainID)
+	key, err := crypto.HexToECDSA("92954368afd3caa1f3ce3ead0069c1af414054aefe1ef9aeacc1bf426222ce38")
+	if err != nil {
+		t.Fatalf("failed to decode test key: %v", err)
+	}
+	header := &types.Header{
+		Number:  common.Big1,
+		Time:    headerTime,
+		BaseFee: big.NewInt(875_000_000),
+	}
+	tx := types.NewTx(&types.DynamicFeeTx{
+		Nonce:     0,
+		GasTipCap: common.Big0,
+		GasFeeCap: new(big.Int).Set(header.BaseFee),
+		Gas:       taiko.AnchorV3V4GasLimit,
+		To:        &to,
+		Data:      taiko.AnchorV4Selector,
+	})
+	signer := types.MakeSigner(chain.Config(), header.Number, header.Time)
+	signedTx, err := types.SignTx(tx, signer, key)
+	if err != nil {
+		t.Fatalf("failed to sign tx: %v", err)
+	}
+
+	isAnchor, err := taikoEngine.ValidateAnchorTx(signedTx, header)
+	if err != nil {
+		t.Fatalf("ValidateAnchorTx returned error: %v", err)
+	}
+	if !isAnchor {
+		t.Fatal("expected AnchorV4 tx to be valid after Shasta activation")
+	}
+}
+
+func taikoL2Address(chainID *big.Int) common.Address {
+	prefix := strings.TrimPrefix(chainID.String(), "0")
+	return common.HexToAddress(
+		"0x" +
+			prefix +
+			strings.Repeat("0", common.AddressLength*2-len(prefix)-len(taiko.TaikoL2AddressSuffix)) +
+			taiko.TaikoL2AddressSuffix,
+	)
+}


### PR DESCRIPTION
## Summary

This PR fixes a startup-time config sync issue that can cause `IsShasta(...)` to return `false` on the first run after upgrading from an older Taiko node version.

## Problem

For nodes initialized on older versions (e.g. `v1.17.4`, which had no `shastaTime` in persisted chain config), startup currently does:

1. Load persisted chain config from DB
2. Create Taiko engine with that config
3. Run genesis/config compatibility logic, which may update DB chain config

If the DB config is migrated during step 3, the Taiko engine still holds the pre-migration config for the lifetime of that process.  
Result: on the first upgraded run, Shasta checks can be stale until a second restart.

## Root Cause

`Taiko` engine caches `chainConfig` at construction time and was not refreshed after `SetupGenesisBlockWithOverride(...)` returned the final config.

## Fix

- Add `SetChainConfig(*params.ChainConfig)` to Taiko engine.
- After `SetupGenesisBlockWithOverride(...)` in `core.NewBlockChain`, update engines that support `SetChainConfig(...)` with the final chain config.
- Keep changes minimal and scoped to config synchronization only.

## Regression Test

Added `eth/taiko_shasta_upgrade_test.go` to reproduce the upgrade path:

- Persist an old genesis config with `ShastaTime=nil`
- Start with new Hoodi genesis
- Assert post-fork AnchorV4 validation succeeds in the same process (no extra restart needed)
