### PR TITLE
chore(params): include Taiko forks in `ChainConfig` description

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -510,6 +510,17 @@ func (c *ChainConfig) Description() string {
 	if c.VerkleTime != nil {
 		banner += fmt.Sprintf(" - Verkle:                      @%-10v\n", *c.VerkleTime)
 	}
+
+	// CHANGE(taiko): add Taiko forks to banner.
+	if c.OntakeBlock != nil {
+		banner += fmt.Sprintf(" - Ontake:                      #%-8v\n", c.OntakeBlock)
+	}
+	if c.PacayaBlock != nil {
+		banner += fmt.Sprintf(" - Pacaya:                      #%-8v\n", c.PacayaBlock)
+	}
+	if c.ShastaTime != nil {
+		banner += fmt.Sprintf(" - Shasta:                      @%-10v\n", *c.ShastaTime)
+	}
 	return banner
 }
 

--- a/params/config.go
+++ b/params/config.go
@@ -510,8 +510,11 @@ func (c *ChainConfig) Description() string {
 	if c.VerkleTime != nil {
 		banner += fmt.Sprintf(" - Verkle:                      @%-10v\n", *c.VerkleTime)
 	}
+	banner += "\n"
 
 	// CHANGE(taiko): add Taiko forks to banner.
+	banner += "Taiko network hard forks:\n"
+
 	if c.OntakeBlock != nil {
 		banner += fmt.Sprintf(" - Ontake:                      #%-8v\n", c.OntakeBlock)
 	}


### PR DESCRIPTION
## Summary
- Updated `ChainConfig.Description()` to print Taiko fork info.
- Added block-based entries for:
  - `OntakeBlock`
  - `PacayaBlock`
- Added timestamp-based entry for:
  - `ShastaTime`
- Kept nil checks so these lines only appear when the fork is configured.

## Why
- Makes Taiko fork activation points visible in the chain config banner output.

## Validation
- Ran: `go test ./params`
- Result: passed (`ok github.com/ethereum/go-ethereum/params`)