### PR TITLE
fix(rawdb): add hexutil.Bytes marshaling override for L1Origin.Signature

### DIFF
--- a/beacon/engine/gen_blockparams.go
+++ b/beacon/engine/gen_blockparams.go
@@ -5,6 +5,7 @@ package engine
 import (
 	"encoding/json"
 	"errors"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -75,7 +76,7 @@ func (p *PayloadAttributes) UnmarshalJSON(input []byte) error {
 	if dec.BaseFeePerGas == nil {
 		return errors.New("missing required field 'baseFeePerGas' for PayloadAttributes")
 	}
-	p.BaseFeePerGas = dec.BaseFeePerGas.ToInt()
+	p.BaseFeePerGas = (*big.Int)(dec.BaseFeePerGas)
 	if dec.BlockMetadata == nil {
 		return errors.New("missing required field 'blockMetadata' for PayloadAttributes")
 	}

--- a/core/rawdb/gen_taiko_l1_origin.go
+++ b/core/rawdb/gen_taiko_l1_origin.go
@@ -8,6 +8,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
 )
 
@@ -22,7 +23,7 @@ func (l L1Origin) MarshalJSON() ([]byte, error) {
 		L1BlockHash        common.Hash           `json:"l1BlockHash" rlp:"optional"`
 		BuildPayloadArgsID [8]byte               `json:"buildPayloadArgsID" rlp:"optional"`
 		IsForcedInclusion  bool                  `json:"isForcedInclusion" rlp:"optional"`
-		Signature          [65]byte              `json:"signature"         rlp:"optional"`
+		Signature          hexutil.Bytes         `json:"signature"         rlp:"optional"`
 	}
 	var enc L1Origin
 	enc.BlockID = (*math.HexOrDecimal256)(l.BlockID)
@@ -31,7 +32,7 @@ func (l L1Origin) MarshalJSON() ([]byte, error) {
 	enc.L1BlockHash = l.L1BlockHash
 	enc.BuildPayloadArgsID = l.BuildPayloadArgsID
 	enc.IsForcedInclusion = l.IsForcedInclusion
-	enc.Signature = l.Signature
+	enc.Signature = l.Signature[:]
 	return json.Marshal(&enc)
 }
 
@@ -44,7 +45,7 @@ func (l *L1Origin) UnmarshalJSON(input []byte) error {
 		L1BlockHash        *common.Hash          `json:"l1BlockHash" rlp:"optional"`
 		BuildPayloadArgsID *[8]byte              `json:"buildPayloadArgsID" rlp:"optional"`
 		IsForcedInclusion  *bool                 `json:"isForcedInclusion" rlp:"optional"`
-		Signature          *[65]byte             `json:"signature"         rlp:"optional"`
+		Signature          *hexutil.Bytes        `json:"signature"         rlp:"optional"`
 	}
 	var dec L1Origin
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -70,7 +71,10 @@ func (l *L1Origin) UnmarshalJSON(input []byte) error {
 		l.IsForcedInclusion = *dec.IsForcedInclusion
 	}
 	if dec.Signature != nil {
-		l.Signature = *dec.Signature
+		if len(*dec.Signature) != len(l.Signature) {
+			return errors.New("field 'signature' has wrong length, need 65 items")
+		}
+		copy(l.Signature[:], *dec.Signature)
 	}
 	return nil
 }

--- a/core/rawdb/taiko_l1_origin.go
+++ b/core/rawdb/taiko_l1_origin.go
@@ -58,6 +58,7 @@ type L1OriginLegacy struct {
 type l1OriginMarshaling struct {
 	BlockID       *math.HexOrDecimal256
 	L1BlockHeight *math.HexOrDecimal256
+	Signature     hexutil.Bytes
 }
 
 // IsPreconfBlock returns true if the L1Origin is for a preconfirmation block.


### PR DESCRIPTION
## Problem

https://github.com/taikoxyz/taiko-geth/pull/531 changed the signature's RPC API to use hex but missed updating the struct-level marshaling used by gencodec. That is, the the signature field was missing a JSON marshaling override, causing it to serialize as a number array (which is Go's default encoding) instead of a hex string. 

This breaks Nethermind client, we discovered that from the tests failing in the NMC PR: https://github.com/NethermindEth/nethermind/pull/10625. When `L1Origin` is embedded inside `PayloadAttributes` for `engine_forkchoiceUpdatedV3`, Nethermind returns "Invalid params" because it can't parse the number array format and expects the hex string by the Ethereum convention.

## Changes

- Add `Signature hexutil.Bytes` to `l1OriginMarshaling`
- Regenerate generated files via `go generate ./...`