### PR TITLE
chore(consensus): lower EIP-4396 skip log to debug

### DIFF
--- a/consensus/taiko/consensus.go
+++ b/consensus/taiko/consensus.go
@@ -213,7 +213,7 @@ func (t *Taiko) verifyHeader(chain consensus.ChainHeaderReader, header, parent *
 					return err
 				}
 			} else {
-				log.Warn(
+				log.Debug(
 					"Skipping EIP-4396 verification due to unknown ancestor",
 					"parent", parent.Hash(),
 					"number", parent.Number,


### PR DESCRIPTION
## Summary
- Demote the `Skipping EIP-4396 verification due to unknown ancestor` log in `consensus/taiko/consensus.go` from `Warn` to `Debug`.
- This message fires during normal sync when a parent header is not yet available, so `Warn` was misleading operators into thinking something was wrong.

## Test plan
- [ ] `go build ./...`
- [ ] `go test ./consensus/taiko/...`
- [ ] Confirm the message no longer appears at default log level during sync, and is still emitted at `--verbosity=4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)