### PR TITLE
feat(core): set Taiko Hoodi Unzen fork time to `2026-05-21 13:00:00 UTC`

### DIFF
--- a/core/taiko_genesis.go
+++ b/core/taiko_genesis.go
@@ -29,7 +29,7 @@ var (
 	DevnetUnzenTime  uint64 = 0
 	MasayaUnzenTime  uint64 = 1_778_158_800
 	MainnetUnzenTime uint64 = math.MaxUint64
-	HoodiUnzenTime   uint64 = math.MaxUint64
+	HoodiUnzenTime   uint64 = 1_779_368_400
 )
 
 // TaikoGenesisBlock returns the Taiko network genesis block configs.


### PR DESCRIPTION
## Summary

- Sets `HoodiUnzenTime` to `1779368400` (2026-05-21 13:00:00 UTC), replacing the `math.MaxUint64` sentinel.
- The existing cascade in [`core/taiko_genesis.go`](core/taiko_genesis.go) propagates the value to `CancunTime`, `PragueTime`, and `OsakaTime` for the Taiko Hoodi testnet automatically.
- Mirrors #552, which set the Masaya Unzen fork time.

## Test plan

- [x] `go build ./...`
- [x] `go test ./params/... ./core/ -run "Taiko|Unzen|Hoodi|Genesis"`
- [ ] Coordinate activation timing with the wider Hoodi rollout (taiko-mono / alethia-reth) before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)