### PR TITLE
feat(eth): gate batch lookup results by network

### DIFF
--- a/eth/taiko_api_backend.go
+++ b/eth/taiko_api_backend.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/miner"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 // ErrProposalLastBlockUncertain indicates the last block for the proposal is not yet deterministic.
@@ -85,6 +86,13 @@ func (s *TaikoAPIBackend) GetSyncMode() (string, error) {
 // when searching for the last block of a given batch ID.
 const maxBatchLookupBlocks = 192 * 21_600
 
+var batchLookupBlockThresholds = map[uint64]uint64{
+	params.TaikoMainnetNetworkID.Uint64():  0,
+	params.TaikoInternalNetworkID.Uint64(): 0,
+	params.MasayaDevnetNetworkID.Uint64():  0,
+	params.TaikoHoodiNetworkID.Uint64():    0,
+}
+
 // TaikoAuthAPIBackend handles L2 node related authorized RPC calls.
 type TaikoAuthAPIBackend struct {
 	eth *Ethereum
@@ -109,6 +117,9 @@ func (a *TaikoAuthAPIBackend) LastL1OriginByBatchID(batchID *math.HexOrDecimal25
 			return nil, ethereum.NotFound
 		}
 	}
+	if a.batchLookupResultBelowThreshold((*big.Int)(blockID)) {
+		return nil, nil
+	}
 
 	return rawdb.ReadL1Origin(a.eth.ChainDb(), (*big.Int)(blockID))
 }
@@ -120,10 +131,20 @@ func (a *TaikoAuthAPIBackend) LastBlockIDByBatchID(batchID *math.HexOrDecimal256
 		return nil, err
 	}
 	if blockID != nil {
+		if a.batchLookupResultBelowThreshold((*big.Int)(blockID)) {
+			return nil, nil
+		}
 		return blockID, nil
 	}
 
-	return a.getLastBlockByBatchId((*big.Int)(batchID))
+	blockID, err = a.getLastBlockByBatchId((*big.Int)(batchID))
+	if err != nil {
+		return nil, err
+	}
+	if a.batchLookupResultBelowThreshold((*big.Int)(blockID)) {
+		return nil, nil
+	}
+	return blockID, nil
 }
 
 // LastCertainBlockIDByBatchID returns the ID of the last block for the given batch in the rawdb.
@@ -131,6 +152,9 @@ func (a *TaikoAuthAPIBackend) LastCertainBlockIDByBatchID(batchID *math.HexOrDec
 	blockID, err := rawdb.ReadBatchToLastBlockID(a.eth.ChainDb(), (*big.Int)(batchID))
 	if err != nil && !errors.Is(err, ethereum.NotFound) {
 		return nil, err
+	}
+	if a.batchLookupResultBelowThreshold((*big.Int)(blockID)) {
+		return nil, nil
 	}
 	return blockID, nil
 }
@@ -144,8 +168,22 @@ func (a *TaikoAuthAPIBackend) LastCertainL1OriginByBatchID(batchID *math.HexOrDe
 	if blockID == nil {
 		return nil, nil
 	}
+	if a.batchLookupResultBelowThreshold((*big.Int)(blockID)) {
+		return nil, nil
+	}
 
 	return rawdb.ReadL1Origin(a.eth.ChainDb(), (*big.Int)(blockID))
+}
+
+func (a *TaikoAuthAPIBackend) batchLookupResultBelowThreshold(blockID *big.Int) bool {
+	if blockID == nil {
+		return false
+	}
+	threshold := batchLookupBlockThresholds[a.eth.networkID]
+	if threshold == 0 {
+		return false
+	}
+	return blockID.Cmp(new(big.Int).SetUint64(threshold)) < 0
 }
 
 // getLastBlockByBatchId traverses the blockchain backwards to find the last Shasta block of the given Shasta batch ID.

--- a/eth/taiko_api_backend.go
+++ b/eth/taiko_api_backend.go
@@ -87,10 +87,10 @@ func (s *TaikoAPIBackend) GetSyncMode() (string, error) {
 const maxBatchLookupBlocks = 192 * 21_600
 
 var batchLookupBlockThresholds = map[uint64]uint64{
-	params.TaikoMainnetNetworkID.Uint64():  0,
+	params.TaikoMainnetNetworkID.Uint64():  4_990_434,
 	params.TaikoInternalNetworkID.Uint64(): 0,
 	params.MasayaDevnetNetworkID.Uint64():  0,
-	params.TaikoHoodiNetworkID.Uint64():    0,
+	params.TaikoHoodiNetworkID.Uint64():    3_951_005,
 }
 
 // TaikoAuthAPIBackend handles L2 node related authorized RPC calls.

--- a/eth/taiko_api_backend.go
+++ b/eth/taiko_api_backend.go
@@ -87,6 +87,7 @@ func (s *TaikoAPIBackend) GetSyncMode() (string, error) {
 const maxBatchLookupBlocks = 192 * 21_600
 
 // CHANGE(taiko): Add per-network minimum block thresholds for batch lookup results.
+// The thresholds are the last Pacaya block IDs for each network.
 var batchLookupBlockThresholds = map[uint64]uint64{
 	params.TaikoMainnetNetworkID.Uint64():  4_990_434,
 	params.TaikoInternalNetworkID.Uint64(): 0,

--- a/eth/taiko_api_backend.go
+++ b/eth/taiko_api_backend.go
@@ -86,6 +86,7 @@ func (s *TaikoAPIBackend) GetSyncMode() (string, error) {
 // when searching for the last block of a given batch ID.
 const maxBatchLookupBlocks = 192 * 21_600
 
+// CHANGE(taiko): Add per-network minimum block thresholds for batch lookup results.
 var batchLookupBlockThresholds = map[uint64]uint64{
 	params.TaikoMainnetNetworkID.Uint64():  4_990_434,
 	params.TaikoInternalNetworkID.Uint64(): 0,
@@ -175,6 +176,7 @@ func (a *TaikoAuthAPIBackend) LastCertainL1OriginByBatchID(batchID *math.HexOrDe
 	return rawdb.ReadL1Origin(a.eth.ChainDb(), (*big.Int)(blockID))
 }
 
+// CHANGE(taiko): Gate batch lookup results by network-specific block thresholds.
 func (a *TaikoAuthAPIBackend) batchLookupResultBelowThreshold(blockID *big.Int) bool {
 	if blockID == nil {
 		return false

--- a/eth/taiko_api_backend_test.go
+++ b/eth/taiko_api_backend_test.go
@@ -221,6 +221,66 @@ func TestLastCertainL1OriginByBatchID(t *testing.T) {
 	}
 }
 
+func TestBatchLookupMethodsReturnNilBelowNetworkThreshold(t *testing.T) {
+	const networkID = 999
+	batchID := big.NewInt(1)
+	blockID := big.NewInt(2)
+	threshold := uint64(3)
+
+	originalThreshold, hadThreshold := batchLookupBlockThresholds[networkID]
+	batchLookupBlockThresholds[networkID] = threshold
+	defer func() {
+		if hadThreshold {
+			batchLookupBlockThresholds[networkID] = originalThreshold
+		} else {
+			delete(batchLookupBlockThresholds, networkID)
+		}
+	}()
+
+	db := rawdb.NewMemoryDatabase()
+	backend := &TaikoAuthAPIBackend{eth: &Ethereum{chainDb: db, networkID: networkID}}
+	expectedOrigin := &rawdb.L1Origin{
+		BlockID:       blockID,
+		L2BlockHash:   common.HexToHash("0x1"),
+		L1BlockHeight: big.NewInt(3),
+		L1BlockHash:   common.HexToHash("0x2"),
+	}
+	rawdb.WriteBatchToLastBlockID(db, batchID, blockID)
+	rawdb.WriteL1Origin(db, blockID, expectedOrigin)
+
+	l1Origin, err := backend.LastL1OriginByBatchID((*math.HexOrDecimal256)(batchID))
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if l1Origin != nil {
+		t.Fatalf("expected nil l1Origin, got %v", l1Origin)
+	}
+
+	lastBlockID, err := backend.LastBlockIDByBatchID((*math.HexOrDecimal256)(batchID))
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if lastBlockID != nil {
+		t.Fatalf("expected nil blockID, got %v", lastBlockID)
+	}
+
+	certainBlockID, err := backend.LastCertainBlockIDByBatchID((*math.HexOrDecimal256)(batchID))
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if certainBlockID != nil {
+		t.Fatalf("expected nil certain blockID, got %v", certainBlockID)
+	}
+
+	certainL1Origin, err := backend.LastCertainL1OriginByBatchID((*math.HexOrDecimal256)(batchID))
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if certainL1Origin != nil {
+		t.Fatalf("expected nil certain l1Origin, got %v", certainL1Origin)
+	}
+}
+
 func newShastaTestChain(t *testing.T) (ethdb.Database, *core.BlockChain, *big.Int, []*types.Block) {
 	t.Helper()
 


### PR DESCRIPTION
## Summary
- Add per-network batch lookup block thresholds for Taiko networks, currently set to `0` placeholders.
- Return `nil, nil` from batch lookup RPC helpers when the resolved block ID is below the current network threshold.
- Cover all four affected lookup methods with a threshold filtering regression test.

## Test Plan
- `go test ./eth -run TestBatchLookupMethodsReturnNilBelowNetworkThreshold -count=1`
- `go test ./eth -run 'Test(LastCertainL1OriginByBatchID|BatchLookupMethodsReturnNilBelowNetworkThreshold|GetLastBlockByBatchId|TaikoAuthBackendExposesBatchLookupMethods|TaikoAPIBackendHidesBatchLookupMethods)' -count=1`