### PR TITLE
chore(eth): increase batch lookup window

### DIFF
--- a/eth/taiko_api_backend.go
+++ b/eth/taiko_api_backend.go
@@ -84,7 +84,7 @@ func (s *TaikoAPIBackend) GetSyncMode() (string, error) {
 
 // maxBatchLookupBlocks defines the maximum number of blocks to look back
 // when searching for the last block of a given batch ID.
-const maxBatchLookupBlocks = 192 * 21_600
+const maxBatchLookupBlocks = 768 * 21_600
 
 // CHANGE(taiko): Add per-network minimum block thresholds for batch lookup results.
 // The thresholds are the last Pacaya block IDs for each network.

--- a/eth/taiko_api_backend_test.go
+++ b/eth/taiko_api_backend_test.go
@@ -102,6 +102,12 @@ func TestGetLastBlockByBatchIdUncertainAtHead(t *testing.T) {
 	}
 }
 
+func TestMaxBatchLookupBlocks(t *testing.T) {
+	if maxBatchLookupBlocks != 768*21_600 {
+		t.Fatalf("expected maxBatchLookupBlocks %d, got %d", 768*21_600, maxBatchLookupBlocks)
+	}
+}
+
 func TestGetLastBlockByBatchIdLookbackLimit(t *testing.T) {
 	chainLength := int(maxBatchLookupBlocks + 2)
 


### PR DESCRIPTION
## Summary
- Increase the batch lookup scan window from `192 * 21_600` to `768 * 21_600`.
- Add a package-level regression test for the Go constant value.

## Test Plan
- `go test ./eth -run TestMaxBatchLookupBlocks -count=1`
- `git diff --check`

Note: this repository does not have a `main` branch; its GitHub default branch is `taiko`, so this PR targets `taiko`.
