### PR TITLE
chore(core): disable Hoodi Unzen fork

### DIFF
--- a/core/taiko_genesis.go
+++ b/core/taiko_genesis.go
@@ -29,7 +29,7 @@ var (
 	DevnetUnzenTime  uint64 = 0
 	MasayaUnzenTime  uint64 = 1_778_158_800
 	MainnetUnzenTime uint64 = math.MaxUint64
-	HoodiUnzenTime   uint64 = 1_779_368_400
+	HoodiUnzenTime   uint64 = math.MaxUint64
 )
 
 // TaikoGenesisBlock returns the Taiko network genesis block configs.


### PR DESCRIPTION
## Summary
- Set the Hoodi Unzen activation timestamp to math.MaxUint64.
- Clear Hoodi Unzen-derived Cancun/Prague/Osaka timestamps when Unzen is disabled so shared chain config state does not retain prior fork timestamps.

## Validation
- gofmt -w core/taiko_genesis.go
- go test ./core -run '^$'