### PR TITLE
feat(vm): add `ZK_GAS_METERING_OVERHEAD` to Unzen zk gas accounting

### DIFF
--- a/core/vm/taiko_zk_gas.go
+++ b/core/vm/taiko_zk_gas.go
@@ -25,7 +25,13 @@ type ZkGasSchedule struct {
 	// per block transaction before opcode and precompile metering begins.
 	// Sourced from the zk-gas spec (taikoxyz/taiko-mono#21669); a value of 0
 	// makes the per-tx charge a no-op.
-	TxIntrinsicZkGas      uint64
+	TxIntrinsicZkGas uint64
+	// ZkGasMeteringOverhead is the fixed zk-gas charged on every opcode
+	// execution and every precompile call, on top of `rawGas * multiplier`.
+	// Covers the proving cost of the zk-gas metering hook itself. Sourced
+	// from the zk-gas spec (taikoxyz/taiko-mono#21695); a value of 0 makes
+	// the per-hook charge a no-op.
+	ZkGasMeteringOverhead uint64
 	OpcodeMultipliers     [256]uint16
 	PrecompileMultipliers [256]uint16
 	SpawnEstimates        SpawnEstimates
@@ -43,16 +49,36 @@ func NewZkGasMeter(schedule *ZkGasSchedule) *ZkGasMeter {
 	return &ZkGasMeter{schedule: schedule}
 }
 
-// ChargeOpcode charges zk gas for a single opcode execution: rawGas * multiplier.
+// ChargeOpcode charges zk gas for a single opcode execution:
+// rawGas * multiplier + ZkGasMeteringOverhead. A schedule overhead of 0
+// makes the addition a no-op.
 func (m *ZkGasMeter) ChargeOpcode(opcode byte, rawGas uint64) error {
 	multiplier := uint64(m.schedule.OpcodeMultipliers[opcode])
-	return m.charge(rawGas, multiplier)
+	cost, overflow := safeMul(rawGas, multiplier)
+	if overflow {
+		return ErrZkGasLimitExceeded
+	}
+	cost, overflow = safeAdd(cost, m.schedule.ZkGasMeteringOverhead)
+	if overflow {
+		return ErrZkGasLimitExceeded
+	}
+	return m.chargeAmount(cost)
 }
 
-// ChargePrecompile charges zk gas for a precompile execution: gasUsed * multiplier.
+// ChargePrecompile charges zk gas for a precompile execution:
+// gasUsed * multiplier + ZkGasMeteringOverhead. A schedule overhead of 0
+// makes the addition a no-op.
 func (m *ZkGasMeter) ChargePrecompile(addrLowByte byte, gasUsed uint64) error {
 	multiplier := uint64(m.schedule.PrecompileMultipliers[addrLowByte])
-	return m.charge(gasUsed, multiplier)
+	cost, overflow := safeMul(gasUsed, multiplier)
+	if overflow {
+		return ErrZkGasLimitExceeded
+	}
+	cost, overflow = safeAdd(cost, m.schedule.ZkGasMeteringOverhead)
+	if overflow {
+		return ErrZkGasLimitExceeded
+	}
+	return m.chargeAmount(cost)
 }
 
 // ChargeTxIntrinsic charges the fixed per-tx intrinsic zk gas defined by the
@@ -127,12 +153,19 @@ func IsSpawnOpcode(op OpCode) bool {
 	}
 }
 
-// charge applies a checked zk gas charge against the current transaction and block budget.
+// charge applies a checked `base * multiplier` zk gas charge against the
+// current transaction and block budget.
 func (m *ZkGasMeter) charge(base, multiplier uint64) error {
 	cost, overflow := safeMul(base, multiplier)
 	if overflow {
 		return ErrZkGasLimitExceeded
 	}
+	return m.chargeAmount(cost)
+}
+
+// chargeAmount applies a precomputed zk gas amount against the current
+// transaction and block budget.
+func (m *ZkGasMeter) chargeAmount(cost uint64) error {
 	nextTx, overflow := safeAdd(m.txZkGasUsed, cost)
 	if overflow {
 		return ErrZkGasLimitExceeded

--- a/core/vm/taiko_zk_gas_runtime_test.go
+++ b/core/vm/taiko_zk_gas_runtime_test.go
@@ -291,7 +291,7 @@ func TestUnzenZkGasParity_EmptyCodeCallShortCircuitUsesSpawnEstimate(t *testing.
 	if err := evm.zkGasTracker.FinishAndCharge(0, gasLeft); err != nil {
 		t.Fatalf("FinishAndCharge returned error: %v", err)
 	}
-	want := UnzenZkGasSchedule.SpawnEstimates.Call * uint64(UnzenZkGasSchedule.OpcodeMultipliers[byte(CALL)])
+	want := UnzenZkGasSchedule.SpawnEstimates.Call*uint64(UnzenZkGasSchedule.OpcodeMultipliers[byte(CALL)]) + UnzenZkGasSchedule.ZkGasMeteringOverhead
 	if got := meter.TxZkGasUsed(); got != want {
 		t.Fatalf("TxZkGasUsed = %d, want %d", got, want)
 	}
@@ -311,7 +311,7 @@ func TestUnzenZkGasParity_EmptyCodeStaticCallShortCircuitUsesSpawnEstimate(t *te
 	if err := evm.zkGasTracker.FinishAndCharge(0, gasLeft); err != nil {
 		t.Fatalf("FinishAndCharge returned error: %v", err)
 	}
-	want := UnzenZkGasSchedule.SpawnEstimates.StaticCall * uint64(UnzenZkGasSchedule.OpcodeMultipliers[byte(STATICCALL)])
+	want := UnzenZkGasSchedule.SpawnEstimates.StaticCall*uint64(UnzenZkGasSchedule.OpcodeMultipliers[byte(STATICCALL)]) + UnzenZkGasSchedule.ZkGasMeteringOverhead
 	if got := meter.TxZkGasUsed(); got != want {
 		t.Fatalf("TxZkGasUsed = %d, want %d", got, want)
 	}
@@ -333,7 +333,7 @@ func TestUnzenZkGasParity_CallOutOfFundsShortCircuitUsesSpawnEstimate(t *testing
 	if err := evm.zkGasTracker.FinishAndCharge(0, gasLeft); err != nil {
 		t.Fatalf("FinishAndCharge returned error: %v", err)
 	}
-	want := UnzenZkGasSchedule.SpawnEstimates.Call * uint64(UnzenZkGasSchedule.OpcodeMultipliers[byte(CALL)])
+	want := UnzenZkGasSchedule.SpawnEstimates.Call*uint64(UnzenZkGasSchedule.OpcodeMultipliers[byte(CALL)]) + UnzenZkGasSchedule.ZkGasMeteringOverhead
 	if got := meter.TxZkGasUsed(); got != want {
 		t.Fatalf("TxZkGasUsed = %d, want %d", got, want)
 	}
@@ -355,7 +355,7 @@ func TestUnzenZkGasParity_CreateOutOfFundsShortCircuitUsesSpawnEstimate(t *testi
 	if err := evm.zkGasTracker.FinishAndCharge(0, gasLeft); err != nil {
 		t.Fatalf("FinishAndCharge returned error: %v", err)
 	}
-	want := UnzenZkGasSchedule.SpawnEstimates.Create * uint64(UnzenZkGasSchedule.OpcodeMultipliers[byte(CREATE)])
+	want := UnzenZkGasSchedule.SpawnEstimates.Create*uint64(UnzenZkGasSchedule.OpcodeMultipliers[byte(CREATE)]) + UnzenZkGasSchedule.ZkGasMeteringOverhead
 	if got := meter.TxZkGasUsed(); got != want {
 		t.Fatalf("TxZkGasUsed = %d, want %d", got, want)
 	}
@@ -380,7 +380,7 @@ func TestUnzenZkGasParity_DepthExceededCallShortCircuitUsesSpawnEstimate(t *test
 	if err := evm.zkGasTracker.FinishAndCharge(depth, gasLeft); err != nil {
 		t.Fatalf("FinishAndCharge returned error: %v", err)
 	}
-	want := UnzenZkGasSchedule.SpawnEstimates.Call * uint64(UnzenZkGasSchedule.OpcodeMultipliers[byte(CALL)])
+	want := UnzenZkGasSchedule.SpawnEstimates.Call*uint64(UnzenZkGasSchedule.OpcodeMultipliers[byte(CALL)]) + UnzenZkGasSchedule.ZkGasMeteringOverhead
 	if got := meter.TxZkGasUsed(); got != want {
 		t.Fatalf("TxZkGasUsed = %d, want %d", got, want)
 	}

--- a/core/vm/taiko_zk_gas_test.go
+++ b/core/vm/taiko_zk_gas_test.go
@@ -144,6 +144,58 @@ func TestZkGasMeter_ChargePrecompile(t *testing.T) {
 	}
 }
 
+func TestZkGasMeter_ChargeOpcode_AddsOverheadOnDefaultUnzen(t *testing.T) {
+	m := NewZkGasMeter(&UnzenZkGasSchedule)
+
+	// ADD opcode: rawGas=3, multiplier=12, +overhead=90 -> cost=126.
+	if err := m.ChargeOpcode(0x01, 3); err != nil {
+		t.Fatalf("unexpected error charging ADD: %v", err)
+	}
+	want := 3*uint64(UnzenZkGasSchedule.OpcodeMultipliers[0x01]) + ZkGasMeteringOverhead
+	if got := m.TxZkGasUsed(); got != want {
+		t.Fatalf("TxZkGasUsed = %d, want %d (raw*mult + overhead)", got, want)
+	}
+}
+
+func TestZkGasMeter_ChargeOpcode_NoOverheadOnMasaya(t *testing.T) {
+	m := NewZkGasMeter(&MasayaUnzenZkGasSchedule)
+
+	// ADD opcode on Masaya: overhead is pinned at 0, so cost is raw*mult only.
+	if err := m.ChargeOpcode(0x01, 3); err != nil {
+		t.Fatalf("unexpected error charging ADD: %v", err)
+	}
+	want := 3 * uint64(MasayaUnzenZkGasSchedule.OpcodeMultipliers[0x01])
+	if got := m.TxZkGasUsed(); got != want {
+		t.Fatalf("TxZkGasUsed = %d, want %d (raw*mult, no overhead)", got, want)
+	}
+}
+
+func TestZkGasMeter_ChargePrecompile_AddsOverheadOnDefaultUnzen(t *testing.T) {
+	m := NewZkGasMeter(&UnzenZkGasSchedule)
+
+	// identity precompile (0x04): gasUsed=18, multiplier=2, +overhead=90 -> cost=126.
+	if err := m.ChargePrecompile(0x04, 18); err != nil {
+		t.Fatalf("unexpected error charging identity: %v", err)
+	}
+	want := 18*uint64(UnzenZkGasSchedule.PrecompileMultipliers[0x04]) + ZkGasMeteringOverhead
+	if got := m.TxZkGasUsed(); got != want {
+		t.Fatalf("TxZkGasUsed = %d, want %d (gasUsed*mult + overhead)", got, want)
+	}
+}
+
+func TestZkGasMeter_ChargePrecompile_NoOverheadOnMasaya(t *testing.T) {
+	m := NewZkGasMeter(&MasayaUnzenZkGasSchedule)
+
+	// identity precompile on Masaya: overhead pinned at 0.
+	if err := m.ChargePrecompile(0x04, 18); err != nil {
+		t.Fatalf("unexpected error charging identity: %v", err)
+	}
+	want := 18 * uint64(MasayaUnzenZkGasSchedule.PrecompileMultipliers[0x04])
+	if got := m.TxZkGasUsed(); got != want {
+		t.Fatalf("TxZkGasUsed = %d, want %d (gasUsed*mult, no overhead)", got, want)
+	}
+}
+
 func TestZkGasMeter_ChargeTxIntrinsic_AddsToInFlight(t *testing.T) {
 	s := testSchedule()
 	s.TxIntrinsicZkGas = 243_000

--- a/core/vm/taiko_zk_gas_unzen.go
+++ b/core/vm/taiko_zk_gas_unzen.go
@@ -27,15 +27,30 @@ const TxIntrinsicZkGas uint64 = 243_000
 // retroactively would break consensus on already-finalized Masaya blocks.
 const MasayaTxIntrinsicZkGas uint64 = 0
 
+// CHANGE(taiko): ZkGasMeteringOverhead is the fixed zk-gas charge applied on
+// every opcode execution and every precompile call on Devnet, Hoodi, and
+// Mainnet during Unzen, on top of `rawGas * multiplier`. Sourced from the
+// zk-gas spec (taikoxyz/taiko-mono#21695); covers the proving cost of the
+// zk-gas metering hook itself.
+const ZkGasMeteringOverhead uint64 = 90
+
+// CHANGE(taiko): MasayaZkGasMeteringOverhead is the per-hook overhead applied
+// on the Taiko Masaya network during Unzen. Pinned at 0 because Masaya
+// activated Unzen before the spec change landed; header difficulty on Unzen
+// blocks encodes the finalized block zk gas, so changing the per-hook charge
+// retroactively would break consensus on already-finalized Masaya blocks.
+const MasayaZkGasMeteringOverhead uint64 = 0
+
 // CHANGE(taiko): UnzenZkGasSchedule is the consensus zk-gas schedule used by
 // Devnet, Hoodi, and Mainnet during the Unzen fork.
-var UnzenZkGasSchedule = unzenZkGasScheduleWith(BlockZkGasLimit, TxIntrinsicZkGas)
+var UnzenZkGasSchedule = unzenZkGasScheduleWith(BlockZkGasLimit, TxIntrinsicZkGas, ZkGasMeteringOverhead)
 
 // CHANGE(taiko): MasayaUnzenZkGasSchedule is the consensus zk-gas schedule
 // used by the Taiko Masaya network during the Unzen fork. Opcode multipliers,
 // precompile multipliers, and spawn estimates are identical to
-// UnzenZkGasSchedule; the per-block budget and per-tx intrinsic charge differ.
-var MasayaUnzenZkGasSchedule = unzenZkGasScheduleWith(MasayaBlockZkGasLimit, MasayaTxIntrinsicZkGas)
+// UnzenZkGasSchedule; the per-block budget, per-tx intrinsic charge, and
+// per-hook metering overhead differ.
+var MasayaUnzenZkGasSchedule = unzenZkGasScheduleWith(MasayaBlockZkGasLimit, MasayaTxIntrinsicZkGas, MasayaZkGasMeteringOverhead)
 
 // CHANGE(taiko): UnzenZkGasScheduleFor returns the Unzen zk-gas schedule for
 // the given chain id. Taiko Masaya (167011) runs the 1B-budget schedule; all
@@ -48,13 +63,15 @@ func UnzenZkGasScheduleFor(chainID *big.Int) *ZkGasSchedule {
 }
 
 // unzenZkGasScheduleWith builds an Unzen-shaped schedule with the requested
-// block limit and per-tx intrinsic charge. Opcode multipliers, precompile
-// multipliers, and spawn estimates are identical across all networks; only
-// the block budget and per-tx intrinsic charge differ.
-func unzenZkGasScheduleWith(blockLimit, txIntrinsicZkGas uint64) ZkGasSchedule {
+// block limit, per-tx intrinsic charge, and per-hook metering overhead.
+// Opcode multipliers, precompile multipliers, and spawn estimates are
+// identical across all networks; only the block budget, per-tx intrinsic
+// charge, and per-hook metering overhead differ.
+func unzenZkGasScheduleWith(blockLimit, txIntrinsicZkGas, zkGasMeteringOverhead uint64) ZkGasSchedule {
 	s := ZkGasSchedule{
-		BlockLimit:       blockLimit,
-		TxIntrinsicZkGas: txIntrinsicZkGas,
+		BlockLimit:            blockLimit,
+		TxIntrinsicZkGas:      txIntrinsicZkGas,
+		ZkGasMeteringOverhead: zkGasMeteringOverhead,
 		SpawnEstimates: SpawnEstimates{
 			Call:         12500,
 			CallCode:     12500,

--- a/core/vm/taiko_zk_gas_unzen_test.go
+++ b/core/vm/taiko_zk_gas_unzen_test.go
@@ -44,6 +44,26 @@ func TestUnzenSchedule_TxIntrinsicZkGas(t *testing.T) {
 	}
 }
 
+// TestUnzenSchedule_ZkGasMeteringOverhead pins the per-network Unzen per-hook
+// metering overhead: Devnet/Internal/Hoodi/Mainnet at 90, Masaya at 0. Masaya's
+// zero pin is consensus-critical — header difficulty on Unzen blocks encodes
+// the finalized block zk gas, so changing the charge for already-finalized
+// Masaya blocks would break their consensus.
+func TestUnzenSchedule_ZkGasMeteringOverhead(t *testing.T) {
+	if got := ZkGasMeteringOverhead; got != 90 {
+		t.Fatalf("ZkGasMeteringOverhead = %d, want 90", got)
+	}
+	if got := MasayaZkGasMeteringOverhead; got != 0 {
+		t.Fatalf("MasayaZkGasMeteringOverhead = %d, want 0", got)
+	}
+	if got := UnzenZkGasSchedule.ZkGasMeteringOverhead; got != 90 {
+		t.Fatalf("UnzenZkGasSchedule.ZkGasMeteringOverhead = %d, want 90", got)
+	}
+	if got := MasayaUnzenZkGasSchedule.ZkGasMeteringOverhead; got != 0 {
+		t.Fatalf("MasayaUnzenZkGasSchedule.ZkGasMeteringOverhead = %d, want 0", got)
+	}
+}
+
 // TestMasayaUnzenSchedule_SharesTablesWithDefault asserts byte-identity of
 // every non-block-limit field. This guards against accidental drift between
 // the two schedules — only the block budget should differ.


### PR DESCRIPTION
## Summary

Mirrors [taikoxyz/taiko-mono#21695](https://github.com/taikoxyz/taiko-mono/pull/21695) (spec change) and [taikoxyz/alethia-reth#183](https://github.com/taikoxyz/alethia-reth/pull/183) (Rust node): adds a flat `ZK_GAS_METERING_OVERHEAD = 90` zk-gas charge to every opcode execution and every precompile call, on top of the existing `rawGas * multiplier`. This accounts for the proving cost of the zk-gas metering hook itself.

Per-tx behaviour now matches the updated spec:

- `tx_zk_gas_used += rawGas * opcodeMultiplier[opcode] + ZK_GAS_METERING_OVERHEAD`
- `tx_zk_gas_used += gasUsed * precompileMultiplier[addr] + ZK_GAS_METERING_OVERHEAD`

`ChargeTxIntrinsic` is **not** affected — the spec applies overhead only to opcode and precompile metering hooks.

## Masaya

Pinned at `MasayaZkGasMeteringOverhead = 0`, mirroring `MasayaTxIntrinsicZkGas`. Masaya activated Unzen before this change landed, so adopting the non-zero value retroactively would break consensus on already-finalized blocks (their header `difficulty` field equals the finalized block zk gas).

## Changes

- [`core/vm/taiko_zk_gas.go`](https://github.com/taikoxyz/taiko-geth/blob/feat/zk-gas-metering-overhead/core/vm/taiko_zk_gas.go) — new `ZkGasMeteringOverhead` field on `ZkGasSchedule`; `ChargeOpcode`/`ChargePrecompile` add the overhead via `safeMul → safeAdd → chargeAmount`; extracted `chargeAmount` so `ChargeTxIntrinsic` keeps its existing single-path budget check.
- [`core/vm/taiko_zk_gas_unzen.go`](https://github.com/taikoxyz/taiko-geth/blob/feat/zk-gas-metering-overhead/core/vm/taiko_zk_gas_unzen.go) — new `ZkGasMeteringOverhead = 90` and `MasayaZkGasMeteringOverhead = 0` constants, threaded through `unzenZkGasScheduleWith`.
- [`core/vm/taiko_zk_gas_test.go`](https://github.com/taikoxyz/taiko-geth/blob/feat/zk-gas-metering-overhead/core/vm/taiko_zk_gas_test.go) — four new tests pinning the per-call overhead on default Unzen and the zero-overhead pin on Masaya, for both opcode and precompile charges.
- [`core/vm/taiko_zk_gas_unzen_test.go`](https://github.com/taikoxyz/taiko-geth/blob/feat/zk-gas-metering-overhead/core/vm/taiko_zk_gas_unzen_test.go) — pins the two new constants and both schedule fields.
- [`core/vm/taiko_zk_gas_runtime_test.go`](https://github.com/taikoxyz/taiko-geth/blob/feat/zk-gas-metering-overhead/core/vm/taiko_zk_gas_runtime_test.go) — adds `+ overhead` to the five short-circuit parity `want` calculations that compute zk gas manually as `spawn * multiplier`. The end-to-end parity harness (`executeUnzenZkGasParityCase` / `CanonicalTxZkGas`) needs no change — both sides route through `ChargeOpcode`/`ChargePrecompile` and stay consistent.

No changes to the interpreter, state processor, or block-validation paths — the overhead lives entirely inside `ZkGasMeter.ChargeOpcode` / `ChargePrecompile`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./core/vm/... ./core/ ./miner/`
- [x] `gofmt` clean
- [x] `go test ./core/vm/` — full suite passes
- [x] `go test ./core/` — state processor Unzen integration tests pass (value-transfer pattern remains correct: no opcode execution → no overhead fires)
- [x] `go test ./miner/` — miner tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)