### PR TITLE
feat(vm): key Unzen precompile zk-gas multipliers by full address

### DIFF
--- a/core/taiko_state_processor_unzen_test.go
+++ b/core/taiko_state_processor_unzen_test.go
@@ -42,9 +42,6 @@ func unzenTestScheduleExhausting() *vm.ZkGasSchedule {
 	for i := range s.OpcodeMultipliers {
 		s.OpcodeMultipliers[i] = math.MaxUint16
 	}
-	for i := range s.PrecompileMultipliers {
-		s.PrecompileMultipliers[i] = math.MaxUint16
-	}
 	return s
 }
 
@@ -184,9 +181,6 @@ func TestApplyTransactionWithEVM_UnzenCommitThenTruncate(t *testing.T) {
 	schedule := &vm.ZkGasSchedule{BlockLimit: 50_000}
 	for i := range schedule.OpcodeMultipliers {
 		schedule.OpcodeMultipliers[i] = 10
-	}
-	for i := range schedule.PrecompileMultipliers {
-		schedule.PrecompileMultipliers[i] = math.MaxUint16
 	}
 
 	gp := NewGasPool(30_000_000)

--- a/core/taiko_zk_gas_sticky_executor_test.go
+++ b/core/taiko_zk_gas_sticky_executor_test.go
@@ -26,12 +26,9 @@ func stickyExecutorSchedule() *vm.ZkGasSchedule {
 	for i := range s.OpcodeMultipliers {
 		s.OpcodeMultipliers[i] = 0
 	}
-	for i := range s.PrecompileMultipliers {
-		s.PrecompileMultipliers[i] = 1
-	}
-	// PrecompileMultipliers[0x0a]=1 — the failed-precompile charge of startGas
-	// (100_000) alone overshoots BlockLimit=1_000.
-	s.PrecompileMultipliers[0x0a] = 1
+	// point_evaluation (0x0a) charges 1×; the failed-precompile charge of
+	// startGas (100_000) alone overshoots BlockLimit=1_000.
+	s.PrecompileMultipliers = map[common.Address]uint16{{19: 0x0a}: 1}
 	return s
 }
 

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -350,7 +350,7 @@ func (evm *EVM) Call(caller common.Address, addr common.Address, input []byte, g
 		// usual tracer/gas accounting that every other precompile error
 		// in this function flows through.
 		if evm.Config.ZkGasMeter != nil {
-			if zkErr := evm.Config.ZkGasMeter.ChargePrecompile(addr[19], precompileZkGasUsed(gasBeforePrecompile, gas, err)); zkErr != nil {
+			if zkErr := evm.Config.ZkGasMeter.ChargePrecompile(addr, precompileZkGasUsed(gasBeforePrecompile, gas, err)); zkErr != nil {
 				evm.setZkGasErr()
 				err = zkErr
 			}
@@ -433,7 +433,7 @@ func (evm *EVM) CallCode(caller common.Address, addr common.Address, input []byt
 		// usual tracer/gas accounting that every other precompile error
 		// in this function flows through.
 		if evm.Config.ZkGasMeter != nil {
-			if zkErr := evm.Config.ZkGasMeter.ChargePrecompile(addr[19], precompileZkGasUsed(gasBeforePrecompile, gas, err)); zkErr != nil {
+			if zkErr := evm.Config.ZkGasMeter.ChargePrecompile(addr, precompileZkGasUsed(gasBeforePrecompile, gas, err)); zkErr != nil {
 				evm.setZkGasErr()
 				err = zkErr
 			}
@@ -497,7 +497,7 @@ func (evm *EVM) DelegateCall(originCaller common.Address, caller common.Address,
 		// usual tracer/gas accounting that every other precompile error
 		// in this function flows through.
 		if evm.Config.ZkGasMeter != nil {
-			if zkErr := evm.Config.ZkGasMeter.ChargePrecompile(addr[19], precompileZkGasUsed(gasBeforePrecompile, gas, err)); zkErr != nil {
+			if zkErr := evm.Config.ZkGasMeter.ChargePrecompile(addr, precompileZkGasUsed(gasBeforePrecompile, gas, err)); zkErr != nil {
 				evm.setZkGasErr()
 				err = zkErr
 			}
@@ -570,7 +570,7 @@ func (evm *EVM) StaticCall(caller common.Address, addr common.Address, input []b
 		// usual tracer/gas accounting that every other precompile error
 		// in this function flows through.
 		if evm.Config.ZkGasMeter != nil {
-			if zkErr := evm.Config.ZkGasMeter.ChargePrecompile(addr[19], precompileZkGasUsed(gasBeforePrecompile, gas, err)); zkErr != nil {
+			if zkErr := evm.Config.ZkGasMeter.ChargePrecompile(addr, precompileZkGasUsed(gasBeforePrecompile, gas, err)); zkErr != nil {
 				evm.setZkGasErr()
 				err = zkErr
 			}

--- a/core/vm/taiko_zk_gas.go
+++ b/core/vm/taiko_zk_gas.go
@@ -3,10 +3,16 @@ package vm
 import (
 	"errors"
 	"math"
+
+	"github.com/ethereum/go-ethereum/common"
 )
 
 // CHANGE(taiko): ErrZkGasLimitExceeded is returned when zk gas arithmetic overflows or exceeds the block limit.
 var ErrZkGasLimitExceeded = errors.New("zk gas limit exceeded")
+
+// CHANGE(taiko): FailsafeMultiplier is the multiplier applied to any precompile
+// absent from a schedule's table, via PrecompileMultiplier.
+const FailsafeMultiplier uint16 = math.MaxUint16
 
 // CHANGE(taiko): SpawnEstimates holds fixed raw-gas estimates for spawn opcodes.
 type SpawnEstimates struct {
@@ -25,9 +31,12 @@ type ZkGasSchedule struct {
 	// per block transaction before opcode and precompile metering begins.
 	// Sourced from the zk-gas spec (taikoxyz/taiko-mono#21669); a value of 0
 	// makes the per-tx charge a no-op.
-	TxIntrinsicZkGas      uint64
-	OpcodeMultipliers     [256]uint16
-	PrecompileMultipliers [256]uint16
+	TxIntrinsicZkGas  uint64
+	OpcodeMultipliers [256]uint16
+	// PrecompileMultipliers maps a precompile's full 20-byte address to its
+	// proving-cost multiplier. Addresses absent from the map resolve to
+	// FailsafeMultiplier via PrecompileMultiplier.
+	PrecompileMultipliers map[common.Address]uint16
 	SpawnEstimates        SpawnEstimates
 }
 
@@ -49,10 +58,20 @@ func (m *ZkGasMeter) ChargeOpcode(opcode byte, rawGas uint64) error {
 	return m.charge(rawGas, multiplier)
 }
 
-// ChargePrecompile charges zk gas for a precompile execution: gasUsed * multiplier.
-func (m *ZkGasMeter) ChargePrecompile(addrLowByte byte, gasUsed uint64) error {
-	multiplier := uint64(m.schedule.PrecompileMultipliers[addrLowByte])
+// ChargePrecompile charges zk gas for a precompile execution: gasUsed * multiplier,
+// where multiplier is keyed by the precompile's full 20-byte address.
+func (m *ZkGasMeter) ChargePrecompile(addr common.Address, gasUsed uint64) error {
+	multiplier := uint64(m.schedule.PrecompileMultiplier(addr))
 	return m.charge(gasUsed, multiplier)
+}
+
+// PrecompileMultiplier returns the proving-cost multiplier for addr, or
+// FailsafeMultiplier when the precompile is not listed in this schedule.
+func (s *ZkGasSchedule) PrecompileMultiplier(addr common.Address) uint16 {
+	if mult, ok := s.PrecompileMultipliers[addr]; ok {
+		return mult
+	}
+	return FailsafeMultiplier
 }
 
 // ChargeTxIntrinsic charges the fixed per-tx intrinsic zk gas defined by the

--- a/core/vm/taiko_zk_gas_runtime_test.go
+++ b/core/vm/taiko_zk_gas_runtime_test.go
@@ -649,7 +649,7 @@ func TestUnzenZkGas_SuccessfulPrecompileExceedingBlockLimit_StickyError(t *testi
 
 	schedule := stickySchedule()
 	// Identity precompile multiplier sized so even minimal gas use overshoots BlockLimit=1000.
-	schedule.PrecompileMultipliers[0x04] = 10_000
+	schedule.PrecompileMultipliers[common.Address{19: 0x04}] = 10_000
 
 	contractAddr := common.HexToAddress("0x1000000000000000000000000000000000000000")
 	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
@@ -888,7 +888,7 @@ func (c *zkGasTraceCollector) CanonicalTxZkGas(schedule *ZkGasSchedule) (uint64,
 		if !frame.precompile {
 			continue
 		}
-		if err := meter.ChargePrecompile(frame.to[19], frame.startGas-frame.leftOverGas); err != nil {
+		if err := meter.ChargePrecompile(frame.to, frame.startGas-frame.leftOverGas); err != nil {
 			return 0, err
 		}
 	}

--- a/core/vm/taiko_zk_gas_sticky_test.go
+++ b/core/vm/taiko_zk_gas_sticky_test.go
@@ -49,12 +49,12 @@ func stickySchedule() *ZkGasSchedule {
 	for i := range s.OpcodeMultipliers {
 		s.OpcodeMultipliers[i] = 0
 	}
-	for i := range s.PrecompileMultipliers {
-		s.PrecompileMultipliers[i] = 1
+	// Every canonical precompile (0x01..0x13) charges 1×; the failed-precompile
+	// charge of startGas (100_000) alone overshoots BlockLimit=1_000.
+	s.PrecompileMultipliers = make(map[common.Address]uint16)
+	for b := byte(0x01); b <= 0x13; b++ {
+		s.PrecompileMultipliers[common.Address{19: b}] = 1
 	}
-	// PrecompileMultipliers[0x0a]=1 — the failed-precompile charge of startGas
-	// (100_000) alone overshoots BlockLimit=1_000.
-	s.PrecompileMultipliers[0x0a] = 1
 	return s
 }
 
@@ -98,8 +98,10 @@ func TestEVMCall_PrecompileOverLimit_RevertsCallSnapshot(t *testing.T) {
 	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
 	statedb.Finalise(true)
 
-	schedule := &ZkGasSchedule{BlockLimit: 1}
-	schedule.PrecompileMultipliers[0x04] = 1
+	schedule := &ZkGasSchedule{
+		BlockLimit:            1,
+		PrecompileMultipliers: map[common.Address]uint16{{19: 0x04}: 1},
+	}
 	meter := NewZkGasMeter(schedule)
 	evm := NewEVM(BlockContext{
 		CanTransfer: func(StateDB, common.Address, *uint256.Int) bool { return true },

--- a/core/vm/taiko_zk_gas_test.go
+++ b/core/vm/taiko_zk_gas_test.go
@@ -3,6 +3,8 @@ package vm
 import (
 	"math"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
 )
 
 func testSchedule() *ZkGasSchedule {
@@ -28,12 +30,12 @@ func testSchedule() *ZkGasSchedule {
 	s.OpcodeMultipliers[0xf1] = 25 // CALL
 	s.OpcodeMultipliers[0xf0] = 1  // CREATE
 
-	// Set a precompile multiplier for testing.
-	for i := range s.PrecompileMultipliers {
-		s.PrecompileMultipliers[i] = math.MaxUint16
+	// Set precompile multipliers for testing; unlisted addresses resolve to
+	// FailsafeMultiplier via PrecompileMultiplier.
+	s.PrecompileMultipliers = map[common.Address]uint16{
+		{19: 0x01}: 81, // ecrecover
+		{19: 0x02}: 10, // sha256
 	}
-	s.PrecompileMultipliers[0x01] = 81 // ecrecover
-	s.PrecompileMultipliers[0x02] = 10 // sha256
 	return s
 }
 
@@ -128,7 +130,7 @@ func TestZkGasMeter_ChargePrecompile(t *testing.T) {
 	m := NewZkGasMeter(testSchedule())
 
 	// ecrecover: gasUsed=3000, multiplier=81, cost=243000
-	if err := m.ChargePrecompile(0x01, 3000); err != nil {
+	if err := m.ChargePrecompile(common.Address{19: 0x01}, 3000); err != nil {
 		t.Fatalf("unexpected error charging ecrecover: %v", err)
 	}
 	if m.TxZkGasUsed() != 243000 {
@@ -136,7 +138,7 @@ func TestZkGasMeter_ChargePrecompile(t *testing.T) {
 	}
 
 	// sha256: gasUsed=100, multiplier=10, cost=1000, total=244000
-	if err := m.ChargePrecompile(0x02, 100); err != nil {
+	if err := m.ChargePrecompile(common.Address{19: 0x02}, 100); err != nil {
 		t.Fatalf("unexpected error charging sha256: %v", err)
 	}
 	if m.TxZkGasUsed() != 244000 {
@@ -294,15 +296,6 @@ func TestUnzenSchedule_SpotChecks(t *testing.T) {
 		{"JUMP opcode", 0x56, s.OpcodeMultipliers, 4},
 		// Failsafe: unassigned opcode should be MaxUint16
 		{"unassigned opcode 0xB0", 0xB0, s.OpcodeMultipliers, math.MaxUint16},
-		// Precompile checks
-		{"ecrecover precompile", 0x01, s.PrecompileMultipliers, 47},
-		{"modexp precompile", 0x05, s.PrecompileMultipliers, 923},
-		{"bn128_mul precompile", 0x07, s.PrecompileMultipliers, 58},
-		{"point_evaluation precompile", 0x0a, s.PrecompileMultipliers, 859},
-		{"blake2f precompile", 0x09, s.PrecompileMultipliers, 166},
-		{"identity precompile", 0x04, s.PrecompileMultipliers, 6},
-		// Failsafe: unassigned precompile should be MaxUint16
-		{"unassigned precompile 0xFF", 0xFF, s.PrecompileMultipliers, math.MaxUint16},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -315,6 +308,31 @@ func TestUnzenSchedule_SpotChecks(t *testing.T) {
 	// Block limit check
 	if s.BlockLimit != 100_000_000 {
 		t.Errorf("expected BlockLimit=100000000, got %d", s.BlockLimit)
+	}
+}
+
+func TestUnzenSchedule_PrecompileSpotChecks(t *testing.T) {
+	s := &UnzenZkGasSchedule
+	tests := []struct {
+		name string
+		addr common.Address
+		want uint16
+	}{
+		{"ecrecover precompile", common.Address{19: 0x01}, 47},
+		{"modexp precompile", common.Address{19: 0x05}, 923},
+		{"bn128_mul precompile", common.Address{19: 0x07}, 58},
+		{"point_evaluation precompile", common.Address{19: 0x0a}, 859},
+		{"blake2f precompile", common.Address{19: 0x09}, 166},
+		{"identity precompile", common.Address{19: 0x04}, 6},
+		// Failsafe: unassigned precompile resolves to FailsafeMultiplier.
+		{"unassigned precompile 0xFF", common.Address{19: 0xFF}, math.MaxUint16},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := s.PrecompileMultiplier(tt.addr); got != tt.want {
+				t.Errorf("got %d, want %d", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/core/vm/taiko_zk_gas_unzen.go
+++ b/core/vm/taiko_zk_gas_unzen.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -64,7 +65,7 @@ func UnzenZkGasScheduleFor(chainID *big.Int) *ZkGasSchedule {
 // unzenZkGasScheduleWith builds an Unzen-shaped schedule from the requested
 // block limit, per-tx intrinsic charge, and opcode/precompile multiplier
 // tables. Spawn estimates are identical across all networks.
-func unzenZkGasScheduleWith(blockLimit, txIntrinsicZkGas uint64, opcodeMultipliers, precompileMultipliers [256]uint16) ZkGasSchedule {
+func unzenZkGasScheduleWith(blockLimit, txIntrinsicZkGas uint64, opcodeMultipliers [256]uint16, precompileMultipliers map[common.Address]uint16) ZkGasSchedule {
 	return ZkGasSchedule{
 		BlockLimit:            blockLimit,
 		TxIntrinsicZkGas:      txIntrinsicZkGas,
@@ -243,31 +244,31 @@ func masayaUnzenOpcodeMultipliers() [256]uint16 {
 }
 
 // masayaUnzenPrecompileMultipliers returns the frozen Masaya precompile
-// multiplier table, pinned at the pre-recalibration values. Frozen for the same
-// consensus reason as masayaUnzenOpcodeMultipliers.
-func masayaUnzenPrecompileMultipliers() [256]uint16 {
-	var m [256]uint16
-	for i := range m {
-		m[i] = math.MaxUint16
+// multiplier table, keyed by full precompile address and pinned at the
+// pre-recalibration values. Frozen for the same consensus reason as
+// masayaUnzenOpcodeMultipliers. Canonical precompiles all live at 0x00…00XX, so
+// common.Address{19: 0xNN} spells their keys. Absent addresses resolve to
+// FailsafeMultiplier.
+func masayaUnzenPrecompileMultipliers() map[common.Address]uint16 {
+	return map[common.Address]uint16{
+		{19: 0x01}: 81,   // ecrecover
+		{19: 0x02}: 10,   // sha256
+		{19: 0x03}: 3,    // ripemd160
+		{19: 0x04}: 2,    // identity
+		{19: 0x05}: 1363, // modexp
+		{19: 0x06}: 38,   // bn128_add
+		{19: 0x07}: 87,   // bn128_mul
+		{19: 0x08}: 82,   // bn128_pairing
+		{19: 0x09}: 243,  // blake2f
+		{19: 0x0a}: 398,  // point_evaluation
+		{19: 0x0b}: 112,  // bls12_g1add
+		{19: 0x0c}: 52,   // bls12_g1msm
+		{19: 0x0e}: 111,  // bls12_g2add
+		{19: 0x0f}: 39,   // bls12_g2msm
+		{19: 0x11}: 134,  // bls12_pairing
+		{19: 0x12}: 159,  // bls12_map_fp_to_g1
+		{19: 0x13}: 112,  // bls12_map_fp2_to_g2
 	}
-	m[0x01] = 81   // ecrecover
-	m[0x02] = 10   // sha256
-	m[0x03] = 3    // ripemd160
-	m[0x04] = 2    // identity
-	m[0x05] = 1363 // modexp
-	m[0x06] = 38   // bn128_add
-	m[0x07] = 87   // bn128_mul
-	m[0x08] = 82   // bn128_pairing
-	m[0x09] = 243  // blake2f
-	m[0x0a] = 398  // point_evaluation
-	m[0x0b] = 112  // bls12_g1add
-	m[0x0c] = 52   // bls12_g1msm
-	m[0x0e] = 111  // bls12_g2add
-	m[0x0f] = 39   // bls12_g2msm
-	m[0x11] = 134  // bls12_pairing
-	m[0x12] = 159  // bls12_map_fp_to_g1
-	m[0x13] = 112  // bls12_map_fp2_to_g2
-	return m
 }
 
 // unzenOpcodeMultipliers returns the recalibrated default opcode multiplier
@@ -430,28 +431,27 @@ func unzenOpcodeMultipliers() [256]uint16 {
 }
 
 // unzenPrecompileMultipliers returns the recalibrated default precompile
-// multiplier table, with fail-safe defaults for unlisted entries.
-func unzenPrecompileMultipliers() [256]uint16 {
-	var m [256]uint16
-	for i := range m {
-		m[i] = math.MaxUint16
+// multiplier table, keyed by full precompile address. Canonical precompiles all
+// live at 0x00…00XX, so common.Address{19: 0xNN} spells their keys. Absent
+// addresses resolve to FailsafeMultiplier.
+func unzenPrecompileMultipliers() map[common.Address]uint16 {
+	return map[common.Address]uint16{
+		{19: 0x01}: 47,  // ecrecover
+		{19: 0x02}: 10,  // sha256
+		{19: 0x03}: 4,   // ripemd160
+		{19: 0x04}: 6,   // identity
+		{19: 0x05}: 923, // modexp
+		{19: 0x06}: 19,  // bn128_add
+		{19: 0x07}: 58,  // bn128_mul
+		{19: 0x08}: 54,  // bn128_pairing
+		{19: 0x09}: 166, // blake2f
+		{19: 0x0a}: 859, // point_evaluation
+		{19: 0x0b}: 201, // bls12_g1add
+		{19: 0x0c}: 93,  // bls12_g1msm
+		{19: 0x0e}: 230, // bls12_g2add
+		{19: 0x0f}: 71,  // bls12_g2msm
+		{19: 0x11}: 365, // bls12_pairing
+		{19: 0x12}: 246, // bls12_map_fp_to_g1
+		{19: 0x13}: 208, // bls12_map_fp2_to_g2
 	}
-	m[0x01] = 47  // ecrecover
-	m[0x02] = 10  // sha256
-	m[0x03] = 4   // ripemd160
-	m[0x04] = 6   // identity
-	m[0x05] = 923 // modexp
-	m[0x06] = 19  // bn128_add
-	m[0x07] = 58  // bn128_mul
-	m[0x08] = 54  // bn128_pairing
-	m[0x09] = 166 // blake2f
-	m[0x0a] = 859 // point_evaluation
-	m[0x0b] = 201 // bls12_g1add
-	m[0x0c] = 93  // bls12_g1msm
-	m[0x0e] = 230 // bls12_g2add
-	m[0x0f] = 71  // bls12_g2msm
-	m[0x11] = 365 // bls12_pairing
-	m[0x12] = 246 // bls12_map_fp_to_g1
-	m[0x13] = 208 // bls12_map_fp2_to_g2
-	return m
 }

--- a/core/vm/taiko_zk_gas_unzen_test.go
+++ b/core/vm/taiko_zk_gas_unzen_test.go
@@ -135,3 +135,81 @@ func TestUnzenZkGasScheduleFor(t *testing.T) {
 		}
 	}
 }
+
+// TestHighRangePrecompileCollisionResolvesToFailsafe is the regression guard: a
+// high-range precompile whose low byte collides with a canonical one must resolve
+// to the failsafe, not the colliding canonical multiplier. No such precompile
+// exists in the Unzen fork today.
+func TestHighRangePrecompileCollisionResolvesToFailsafe(t *testing.T) {
+	// L1Sload-style address: low byte 0x01 collides with ecrecover, upper bytes differ.
+	collider := common.HexToAddress("0x1670000000000000000000000000000000010001")
+	// identity-style collider: low byte 0x04.
+	identityCollider := common.HexToAddress("0x1670000000000000000000000000000000010004")
+	ecrecover := common.Address{19: 0x01}
+
+	if got := UnzenZkGasSchedule.PrecompileMultiplier(ecrecover); got != 47 {
+		t.Fatalf("default ecrecover = %d, want 47", got)
+	}
+	if got := UnzenZkGasSchedule.PrecompileMultiplier(collider); got != math.MaxUint16 {
+		t.Fatalf("default collider = %d, want failsafe %d", got, uint16(math.MaxUint16))
+	}
+	if got := UnzenZkGasSchedule.PrecompileMultiplier(identityCollider); got != math.MaxUint16 {
+		t.Fatalf("default identity collider = %d, want failsafe %d", got, uint16(math.MaxUint16))
+	}
+
+	if got := MasayaUnzenZkGasSchedule.PrecompileMultiplier(ecrecover); got != 81 {
+		t.Fatalf("Masaya ecrecover = %d, want frozen 81", got)
+	}
+	if got := MasayaUnzenZkGasSchedule.PrecompileMultiplier(collider); got != math.MaxUint16 {
+		t.Fatalf("Masaya collider = %d, want failsafe %d", got, uint16(math.MaxUint16))
+	}
+	if got := MasayaUnzenZkGasSchedule.PrecompileMultiplier(identityCollider); got != math.MaxUint16 {
+		t.Fatalf("Masaya identity collider = %d, want failsafe %d", got, uint16(math.MaxUint16))
+	}
+}
+
+// TestFullAddressLookupPreservesCanonicalPrecompileMultipliers pins every canonical
+// precompile (0x01..=0x13) to its exact value on both schedules, so finalized blocks
+// stay byte-identical — including Masaya, whose finalized block zk-gas total is committed
+// to the header difficulty field. The len()==17 assertions guard against a dropped or
+// duplicated entry: either changes the count.
+func TestFullAddressLookupPreservesCanonicalPrecompileMultipliers(t *testing.T) {
+	defaultExpected := map[byte]uint16{
+		0x01: 47, 0x02: 10, 0x03: 4, 0x04: 6, 0x05: 923, 0x06: 19, 0x07: 58,
+		0x08: 54, 0x09: 166, 0x0a: 859, 0x0b: 201, 0x0c: 93, 0x0e: 230, 0x0f: 71,
+		0x11: 365, 0x12: 246, 0x13: 208,
+	}
+	for b, want := range defaultExpected {
+		if got := UnzenZkGasSchedule.PrecompileMultiplier(common.Address{19: b}); got != want {
+			t.Errorf("default precompile %#04x = %d, want %d", b, got, want)
+		}
+	}
+	if got := len(UnzenZkGasSchedule.PrecompileMultipliers); got != 17 {
+		t.Errorf("default precompile table has %d entries, want 17", got)
+	}
+
+	masayaExpected := map[byte]uint16{
+		0x01: 81, 0x02: 10, 0x03: 3, 0x04: 2, 0x05: 1363, 0x06: 38, 0x07: 87,
+		0x08: 82, 0x09: 243, 0x0a: 398, 0x0b: 112, 0x0c: 52, 0x0e: 111, 0x0f: 39,
+		0x11: 134, 0x12: 159, 0x13: 112,
+	}
+	for b, want := range masayaExpected {
+		if got := MasayaUnzenZkGasSchedule.PrecompileMultiplier(common.Address{19: b}); got != want {
+			t.Errorf("Masaya precompile %#04x = %d, want %d", b, got, want)
+		}
+	}
+	if got := len(MasayaUnzenZkGasSchedule.PrecompileMultipliers); got != 17 {
+		t.Errorf("Masaya precompile table has %d entries, want 17", got)
+	}
+
+	// Gaps in the canonical range (0x0d, 0x10 unassigned) and out-of-range bytes
+	// resolve to the failsafe on both schedules.
+	for _, b := range []byte{0x0d, 0x10, 0x14} {
+		if got := UnzenZkGasSchedule.PrecompileMultiplier(common.Address{19: b}); got != math.MaxUint16 {
+			t.Errorf("default unlisted %#04x = %d, want failsafe", b, got)
+		}
+		if got := MasayaUnzenZkGasSchedule.PrecompileMultiplier(common.Address{19: b}); got != math.MaxUint16 {
+			t.Errorf("Masaya unlisted %#04x = %d, want failsafe", b, got)
+		}
+	}
+}

--- a/core/vm/taiko_zk_gas_unzen_test.go
+++ b/core/vm/taiko_zk_gas_unzen_test.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -53,8 +54,8 @@ func TestMasayaUnzenSchedule_FreezesPreRecalibrationMultipliers(t *testing.T) {
 	if MasayaUnzenZkGasSchedule.OpcodeMultipliers == UnzenZkGasSchedule.OpcodeMultipliers {
 		t.Fatal("MasayaUnzenZkGasSchedule.OpcodeMultipliers must differ from the recalibrated default")
 	}
-	if MasayaUnzenZkGasSchedule.PrecompileMultipliers == UnzenZkGasSchedule.PrecompileMultipliers {
-		t.Fatal("MasayaUnzenZkGasSchedule.PrecompileMultipliers must differ from the recalibrated default")
+	if MasayaUnzenZkGasSchedule.PrecompileMultiplier(common.Address{19: 0x01}) == UnzenZkGasSchedule.PrecompileMultiplier(common.Address{19: 0x01}) {
+		t.Fatal("MasayaUnzenZkGasSchedule precompile table must differ from the recalibrated default")
 	}
 	// Spot-check known recalibrated entries so this guard fails if the two
 	// tables ever realign: keccak256 (0x20) went 85 -> 31 for the default while
@@ -62,7 +63,7 @@ func TestMasayaUnzenSchedule_FreezesPreRecalibrationMultipliers(t *testing.T) {
 	if MasayaUnzenZkGasSchedule.OpcodeMultipliers[0x20] == UnzenZkGasSchedule.OpcodeMultipliers[0x20] {
 		t.Fatal("keccak256 (0x20) opcode multiplier must differ between Masaya and default")
 	}
-	if MasayaUnzenZkGasSchedule.PrecompileMultipliers[0x05] == UnzenZkGasSchedule.PrecompileMultipliers[0x05] {
+	if MasayaUnzenZkGasSchedule.PrecompileMultiplier(common.Address{19: 0x05}) == UnzenZkGasSchedule.PrecompileMultiplier(common.Address{19: 0x05}) {
 		t.Fatal("modexp (0x05) precompile multiplier must differ between Masaya and default")
 	}
 	if MasayaUnzenZkGasSchedule.SpawnEstimates != UnzenZkGasSchedule.SpawnEstimates {
@@ -87,16 +88,16 @@ func TestUnzenSchedule_Multipliers(t *testing.T) {
 	if got := UnzenZkGasSchedule.OpcodeMultipliers[0xac]; got != math.MaxUint16 {
 		t.Fatalf("default unlisted (0xac) = %d, want failsafe %d", got, uint16(math.MaxUint16))
 	}
-	if got := UnzenZkGasSchedule.PrecompileMultipliers[0x05]; got != 923 {
+	if got := UnzenZkGasSchedule.PrecompileMultiplier(common.Address{19: 0x05}); got != 923 {
 		t.Fatalf("default modexp (0x05) = %d, want 923", got)
 	}
-	if got := UnzenZkGasSchedule.PrecompileMultipliers[0x01]; got != 47 {
+	if got := UnzenZkGasSchedule.PrecompileMultiplier(common.Address{19: 0x01}); got != 47 {
 		t.Fatalf("default ecrecover (0x01) = %d, want 47", got)
 	}
-	if got := UnzenZkGasSchedule.PrecompileMultipliers[0x04]; got != 6 {
+	if got := UnzenZkGasSchedule.PrecompileMultiplier(common.Address{19: 0x04}); got != 6 {
 		t.Fatalf("default identity (0x04) = %d, want 6", got)
 	}
-	if got := UnzenZkGasSchedule.PrecompileMultipliers[0x14]; got != math.MaxUint16 {
+	if got := UnzenZkGasSchedule.PrecompileMultiplier(common.Address{19: 0x14}); got != math.MaxUint16 {
 		t.Fatalf("default unlisted precompile (0x14) = %d, want failsafe %d", got, uint16(math.MaxUint16))
 	}
 
@@ -104,7 +105,7 @@ func TestUnzenSchedule_Multipliers(t *testing.T) {
 	if got := MasayaUnzenZkGasSchedule.OpcodeMultipliers[0x20]; got != 85 {
 		t.Fatalf("Masaya keccak256 (0x20) = %d, want frozen 85", got)
 	}
-	if got := MasayaUnzenZkGasSchedule.PrecompileMultipliers[0x05]; got != 1363 {
+	if got := MasayaUnzenZkGasSchedule.PrecompileMultiplier(common.Address{19: 0x05}); got != 1363 {
 		t.Fatalf("Masaya modexp (0x05) = %d, want frozen 1363", got)
 	}
 }

--- a/miner/taiko_worker_test.go
+++ b/miner/taiko_worker_test.go
@@ -125,9 +125,6 @@ func TestApplyTransaction_SealerZkGasExhaustionSurface(t *testing.T) {
 	for i := range schedule.OpcodeMultipliers {
 		schedule.OpcodeMultipliers[i] = math.MaxUint16
 	}
-	for i := range schedule.PrecompileMultipliers {
-		schedule.PrecompileMultipliers[i] = math.MaxUint16
-	}
 
 	blockCtx := vm.BlockContext{
 		CanTransfer: core.CanTransfer,


### PR DESCRIPTION
## Summary

Ports [alethia-reth#201](https://github.com/taikoxyz/alethia-reth/pull/201) to taiko-geth: re-keys the Unzen zk-gas **precompile** multipliers from the called address's **low byte** to the **full 20-byte address**, with a fail-safe fallback for any address absent from the schedule.

Previously the meter selected a precompile's proving-cost multiplier with `PrecompileMultipliers[addr[19]]`. That is correct for the canonical EVM precompiles (`0x00…0001`..`0x00…0013`), but a high-range precompile collides on its low byte with a canonical one — e.g. an `L1Sload`-style address `0x…010001` shares low byte `0x01` with `ecrecover`. If such a precompile were ever metered through this path it would be charged the canonical multiplier at the colliding low byte, and the `MaxUint16` fail-safe wouldn't help because that slot is already populated.

## Change

- `ZkGasSchedule.PrecompileMultipliers`: `[256]uint16` (low-byte index) → `map[common.Address]uint16` (full-address key).
- New `ZkGasSchedule.PrecompileMultiplier(addr)` accessor: returns the mapped value, or `FailsafeMultiplier` (`math.MaxUint16`) when the address is absent.
- `ChargePrecompile(addr common.Address, gasUsed uint64)` (was `addrLowByte byte`); the four EVM metering call sites (`Call`/`CallCode`/`DelegateCall`/`StaticCall`) pass the full `addr`.
- Both schedule tables rewritten as full-address maps; canonical keys spelled `common.Address{19: 0xNN}` (the Go equivalent of revm's `Address::with_last_byte`). Opcode multipliers and spawn estimates are untouched (opcodes are genuinely single-byte).

## Consensus safety (no Masaya/Mainnet/Hoodi impact, no reset)

Every multiplier value is transcribed **bit-identically** from the prior arrays — verified programmatically against the base branch (17 entries per schedule, all values matching). The only addresses that reach `ChargePrecompile` today are the canonical precompiles, all at `0x00…00XX`, so full-address keying returns the exact same multiplier for every precompile reachable now. The two schemes only diverge on addresses that don't exist in the fork.

Masaya commits its finalized-block zk-gas total to the header `difficulty` field (the reason the frozen Masaya table exists), so byte-identical charges mean **no change to any finalized block** and no devnet reset. A high-range collider now resolves to the fail-safe instead of a wrong canonical value, hardening the path before any high-range precompile is introduced.

## Tests

- `TestHighRangePrecompileCollisionResolvesToFailsafe` — the regression guard: high-range colliders (`…010001`/`…010004`) resolve to the fail-safe on both schedules, while canonical `ecrecover`/`identity` keep their real multipliers.
- `TestFullAddressLookupPreservesCanonicalPrecompileMultipliers` — pins all 17 canonical multipliers for both the default and frozen Masaya schedules, plus fail-safe for the `0x0d`/`0x10`/`0x14` gaps, and asserts `len(table) == 17` per schedule (the portable stand-in for #201's `precompile_tables_have_no_duplicate_addresses` guard — Go `[20]byte` map keys aren't compile-time constants, so duplicate keys aren't caught by the compiler).
- Existing schedule/sticky-error/state-processor tests migrated to the new API with unchanged numbers; mutation-tested to confirm they catch a wrong/dropped/duplicated value.

`gofmt` / `go vet` / `go build ./...` / `go test ./core/... ./core/vm/... ./miner/...` — all green.

## Out of scope

No `L1Sload`/`L1StaticCall` entries (they don't exist in the fork), no chainspec/genesis changes, no opcode/spawn-estimate changes.

Refs taikoxyz/alethia-reth#201

🤖 Generated with [Claude Code](https://claude.com/claude-code)