### PR TITLE
fix(vm): correct Unzen BLS12 precompile addresses and add CLZ opcode

### DIFF
--- a/core/vm/taiko_zk_gas_unzen.go
+++ b/core/vm/taiko_zk_gas_unzen.go
@@ -250,7 +250,11 @@ func masayaUnzenOpcodeMultipliers() [256]uint16 {
 // common.Address{19: 0xNN} spells their keys. Absent addresses resolve to
 // FailsafeMultiplier. p256verify (RIP-7212, 0x100) is deliberately omitted here:
 // it was never in Masaya's finalized schedule, so adding it would break
-// consensus on already-finalized Masaya Unzen blocks.
+// consensus on already-finalized Masaya Unzen blocks. The BLS12 G2/pairing/map
+// precompiles also stay keyed at the pre-final EIP-2537 draft addresses
+// (0x0e/0x0f/0x11/0x12/0x13) rather than the canonical Osaka addresses
+// (0x0d/0x0e/0x0f/0x10/0x11); the default schedule was corrected in
+// taikoxyz/taiko-mono#21749, but Masaya's keys must stay frozen for the same reason.
 func masayaUnzenPrecompileMultipliers() map[common.Address]uint16 {
 	return map[common.Address]uint16{
 		{19: 0x01}: 81,   // ecrecover
@@ -451,11 +455,11 @@ func unzenPrecompileMultipliers() map[common.Address]uint16 {
 		{19: 0x0a}: 859, // point_evaluation
 		{19: 0x0b}: 201, // bls12_g1add
 		{19: 0x0c}: 93,  // bls12_g1msm
-		{19: 0x0e}: 230, // bls12_g2add
-		{19: 0x0f}: 71,  // bls12_g2msm
-		{19: 0x11}: 365, // bls12_pairing
-		{19: 0x12}: 246, // bls12_map_fp_to_g1
-		{19: 0x13}: 208, // bls12_map_fp2_to_g2
+		{19: 0x0d}: 230, // bls12_g2add
+		{19: 0x0e}: 71,  // bls12_g2msm
+		{19: 0x0f}: 365, // bls12_pairing
+		{19: 0x10}: 246, // bls12_map_fp_to_g1
+		{19: 0x11}: 208, // bls12_map_fp2_to_g2
 		// p256verify (RIP-7212) lives at the two-byte address 0x100, so its key
 		// is {18: 0x01}, not the {19: 0xNN} form the canonical precompiles use.
 		{18: 0x01}: 163, // p256verify

--- a/core/vm/taiko_zk_gas_unzen.go
+++ b/core/vm/taiko_zk_gas_unzen.go
@@ -86,6 +86,9 @@ func unzenZkGasScheduleWith(blockLimit, txIntrinsicZkGas uint64, opcodeMultiplie
 // table, pinned at the pre-recalibration values. Recalibrating these
 // retroactively would break consensus on Masaya's already-finalized Unzen
 // blocks, so they stay frozen — same rationale as MasayaTxIntrinsicZkGas.
+// CLZ (0x1e, EIP-7939) is intentionally absent and resolves to the failsafe;
+// the default schedule added it in taikoxyz/taiko-mono#21749, but Masaya's
+// table must stay frozen for the same consensus reason.
 func masayaUnzenOpcodeMultipliers() [256]uint16 {
 	var m [256]uint16
 	for i := range m {
@@ -310,6 +313,7 @@ func unzenOpcodeMultipliers() [256]uint16 {
 	m[0x1b] = 24  // SHL
 	m[0x1c] = 22  // SHR
 	m[0x1d] = 21  // SAR
+	m[0x1e] = 14  // CLZ
 	m[0x20] = 31  // KECCAK256
 	m[0x30] = 19  // ADDRESS
 	m[0x31] = 4   // BALANCE

--- a/core/vm/taiko_zk_gas_unzen_test.go
+++ b/core/vm/taiko_zk_gas_unzen_test.go
@@ -79,6 +79,9 @@ func TestUnzenSchedule_Multipliers(t *testing.T) {
 	if got := UnzenZkGasSchedule.OpcodeMultipliers[0x20]; got != 31 {
 		t.Fatalf("default keccak256 (0x20) = %d, want 31", got)
 	}
+	if got := UnzenZkGasSchedule.OpcodeMultipliers[0x1e]; got != 14 {
+		t.Fatalf("default CLZ (0x1e) = %d, want 14", got)
+	}
 	if got := UnzenZkGasSchedule.OpcodeMultipliers[0xf1]; got != 20 {
 		t.Fatalf("default CALL (0xf1) = %d, want 20", got)
 	}
@@ -107,6 +110,9 @@ func TestUnzenSchedule_Multipliers(t *testing.T) {
 	// Frozen Masaya schedule.
 	if got := MasayaUnzenZkGasSchedule.OpcodeMultipliers[0x20]; got != 85 {
 		t.Fatalf("Masaya keccak256 (0x20) = %d, want frozen 85", got)
+	}
+	if got := MasayaUnzenZkGasSchedule.OpcodeMultipliers[0x1e]; got != math.MaxUint16 {
+		t.Fatalf("Masaya CLZ (0x1e) = %d, want frozen failsafe %d", got, uint16(math.MaxUint16))
 	}
 	if got := MasayaUnzenZkGasSchedule.PrecompileMultiplier(common.Address{19: 0x05}); got != 1363 {
 		t.Fatalf("Masaya modexp (0x05) = %d, want frozen 1363", got)

--- a/core/vm/taiko_zk_gas_unzen_test.go
+++ b/core/vm/taiko_zk_gas_unzen_test.go
@@ -171,16 +171,18 @@ func TestHighRangePrecompileCollisionResolvesToFailsafe(t *testing.T) {
 	}
 }
 
-// TestFullAddressLookupPreservesCanonicalPrecompileMultipliers pins every canonical
-// precompile (0x01..=0x13) to its exact value on both schedules, so finalized blocks
-// stay byte-identical — including Masaya, whose finalized block zk-gas total is committed
-// to the header difficulty field. The len() assertions (default 18, Masaya 17) guard
-// against a dropped or duplicated entry: either changes the count.
+// TestFullAddressLookupPreservesCanonicalPrecompileMultipliers pins every precompile
+// multiplier on both schedules to its exact value, so finalized blocks stay
+// byte-identical — including Masaya, whose finalized block zk-gas total is committed
+// to the header difficulty field. The default schedule keys BLS12 at the canonical
+// Osaka addresses (0x0b..0x11); Masaya stays frozen at the pre-final EIP-2537 draft
+// addresses (0x0b,0x0c,0x0e,0x0f,0x11,0x12,0x13). The len() assertions (default 18,
+// Masaya 17) guard against a dropped or duplicated entry: either changes the count.
 func TestFullAddressLookupPreservesCanonicalPrecompileMultipliers(t *testing.T) {
 	defaultExpected := map[byte]uint16{
 		0x01: 47, 0x02: 10, 0x03: 4, 0x04: 6, 0x05: 923, 0x06: 19, 0x07: 58,
-		0x08: 54, 0x09: 166, 0x0a: 859, 0x0b: 201, 0x0c: 93, 0x0e: 230, 0x0f: 71,
-		0x11: 365, 0x12: 246, 0x13: 208,
+		0x08: 54, 0x09: 166, 0x0a: 859, 0x0b: 201, 0x0c: 93, 0x0d: 230, 0x0e: 71,
+		0x0f: 365, 0x10: 246, 0x11: 208,
 	}
 	for b, want := range defaultExpected {
 		if got := UnzenZkGasSchedule.PrecompileMultiplier(common.Address{19: b}); got != want {
@@ -216,12 +218,16 @@ func TestFullAddressLookupPreservesCanonicalPrecompileMultipliers(t *testing.T) 
 		t.Errorf("Masaya precompile table has %d entries, want 17", got)
 	}
 
-	// Gaps in the canonical range (0x0d, 0x10 unassigned) and out-of-range bytes
-	// resolve to the failsafe on both schedules.
-	for _, b := range []byte{0x0d, 0x10, 0x14} {
+	// The default schedule keys BLS12 at the canonical Osaka addresses, so its gaps
+	// are 0x12/0x13 (vacated by the re-keying) plus out-of-range 0x14.
+	for _, b := range []byte{0x12, 0x13, 0x14} {
 		if got := UnzenZkGasSchedule.PrecompileMultiplier(common.Address{19: b}); got != math.MaxUint16 {
 			t.Errorf("default unlisted %#04x = %d, want failsafe", b, got)
 		}
+	}
+	// Masaya stays frozen at the pre-final draft addresses, so its gaps remain
+	// 0x0d/0x10 plus out-of-range 0x14.
+	for _, b := range []byte{0x0d, 0x10, 0x14} {
 		if got := MasayaUnzenZkGasSchedule.PrecompileMultiplier(common.Address{19: b}); got != math.MaxUint16 {
 			t.Errorf("Masaya unlisted %#04x = %d, want failsafe", b, got)
 		}


### PR DESCRIPTION
## Summary

Ports [taikoxyz/taiko-mono#21749](https://github.com/taikoxyz/taiko-mono/pull/21749) (which fixed `zk_gas_spec.md`) into the taiko-geth implementation. Two independent fixes to the **default** Unzen zk-gas schedule in `core/vm/taiko_zk_gas_unzen.go`, one commit each. The frozen Masaya schedule is left unchanged.

### 1. Re-key BLS12-381 precompiles to canonical Osaka addresses

The EVM dispatches the Osaka BLS precompiles at the canonical EIP-2537 final addresses (`PrecompiledContractsOsaka`), but the default zk-gas table keyed five of them at the obsolete pre-final draft addresses. A real call to `bls12_g2add` (`0x0d`) or `bls12_map_fp_to_g1` (`0x10`) therefore missed the table, resolved to the failsafe multiplier (`max(uint16)`), and **bricked the block**; `g2msm`/`pairing`/`map_fp2_to_g2` silently got the wrong multiplier. Re-keying is value-preserving — only the keys move:

| precompile | before | after | multiplier |
| --- | --- | --- | ---: |
| `bls12_g2add` | `0x0e` | **`0x0d`** | 230 |
| `bls12_g2msm` | `0x0f` | **`0x0e`** | 71 |
| `bls12_pairing` | `0x11` | **`0x0f`** | 365 |
| `bls12_map_fp_to_g1` | `0x12` | **`0x10`** | 246 |
| `bls12_map_fp2_to_g2` | `0x13` | **`0x11`** | 208 |

After this change the default table's keys are exactly the `PrecompiledContractsOsaka` address set.

### 2. Add the CLZ opcode (EIP-7939)

CLZ (count leading zeros, `0x1e`) is enabled in Osaka but was absent from the default opcode multiplier table, so any block executing it hit the failsafe and bricked. Adds `m[0x1e] = 14`.

## Masaya stays frozen

The `masayaUnzen*` tables keep the same (draft) BLS keys and have no CLZ entry — **intentionally**. Masaya is already live on Unzen, and header difficulty on its finalized blocks commits the block zk-gas total, so changing its keys/values would break consensus on already-finalized blocks. This mirrors the existing deliberate omission of p256verify from Masaya. Only doc comments were added to record the rationale. Documented consequence: on Masaya, canonical `g2add`/`map_fp_to_g1` and CLZ resolve to the failsafe.

## Tests

`core/vm/taiko_zk_gas_unzen_test.go` updated to pin the canonical default keys and the CLZ multiplier, with the default/Masaya gap checks split. `masayaExpected` and its entry count are unchanged — the freeze guarantee. Full `core/vm` suite passes; `go build ./...` clean; gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)