### PR TITLE
feat(vm): lower default Unzen modexp zk-gas multiplier to 154

### DIFF
--- a/core/vm/taiko_zk_gas_test.go
+++ b/core/vm/taiko_zk_gas_test.go
@@ -319,7 +319,7 @@ func TestUnzenSchedule_PrecompileSpotChecks(t *testing.T) {
 		want uint16
 	}{
 		{"ecrecover precompile", common.Address{19: 0x01}, 47},
-		{"modexp precompile", common.Address{19: 0x05}, 923},
+		{"modexp precompile", common.Address{19: 0x05}, 154},
 		{"bn128_mul precompile", common.Address{19: 0x07}, 58},
 		{"point_evaluation precompile", common.Address{19: 0x0a}, 859},
 		{"blake2f precompile", common.Address{19: 0x09}, 166},

--- a/core/vm/taiko_zk_gas_unzen.go
+++ b/core/vm/taiko_zk_gas_unzen.go
@@ -451,7 +451,7 @@ func unzenPrecompileMultipliers() map[common.Address]uint16 {
 		{19: 0x02}: 10,  // sha256
 		{19: 0x03}: 4,   // ripemd160
 		{19: 0x04}: 6,   // identity
-		{19: 0x05}: 923, // modexp
+		{19: 0x05}: 154, // modexp
 		{19: 0x06}: 19,  // bn128_add
 		{19: 0x07}: 58,  // bn128_mul
 		{19: 0x08}: 54,  // bn128_pairing

--- a/core/vm/taiko_zk_gas_unzen_test.go
+++ b/core/vm/taiko_zk_gas_unzen_test.go
@@ -59,7 +59,7 @@ func TestMasayaUnzenSchedule_FreezesPreRecalibrationMultipliers(t *testing.T) {
 	}
 	// Spot-check known recalibrated entries so this guard fails if the two
 	// tables ever realign: keccak256 (0x20) went 85 -> 31 for the default while
-	// Masaya stays at 85; modexp (0x05) went 1363 -> 923 while Masaya stays at 1363.
+	// Masaya stays at 85; modexp (0x05) went 1363 -> 154 while Masaya stays at 1363.
 	if MasayaUnzenZkGasSchedule.OpcodeMultipliers[0x20] == UnzenZkGasSchedule.OpcodeMultipliers[0x20] {
 		t.Fatal("keccak256 (0x20) opcode multiplier must differ between Masaya and default")
 	}
@@ -91,8 +91,8 @@ func TestUnzenSchedule_Multipliers(t *testing.T) {
 	if got := UnzenZkGasSchedule.OpcodeMultipliers[0xac]; got != math.MaxUint16 {
 		t.Fatalf("default unlisted (0xac) = %d, want failsafe %d", got, uint16(math.MaxUint16))
 	}
-	if got := UnzenZkGasSchedule.PrecompileMultiplier(common.Address{19: 0x05}); got != 923 {
-		t.Fatalf("default modexp (0x05) = %d, want 923", got)
+	if got := UnzenZkGasSchedule.PrecompileMultiplier(common.Address{19: 0x05}); got != 154 {
+		t.Fatalf("default modexp (0x05) = %d, want 154", got)
 	}
 	if got := UnzenZkGasSchedule.PrecompileMultiplier(common.Address{19: 0x01}); got != 47 {
 		t.Fatalf("default ecrecover (0x01) = %d, want 47", got)
@@ -186,7 +186,7 @@ func TestHighRangePrecompileCollisionResolvesToFailsafe(t *testing.T) {
 // Masaya 17) guard against a dropped or duplicated entry: either changes the count.
 func TestFullAddressLookupPreservesCanonicalPrecompileMultipliers(t *testing.T) {
 	defaultExpected := map[byte]uint16{
-		0x01: 47, 0x02: 10, 0x03: 4, 0x04: 6, 0x05: 923, 0x06: 19, 0x07: 58,
+		0x01: 47, 0x02: 10, 0x03: 4, 0x04: 6, 0x05: 154, 0x06: 19, 0x07: 58,
 		0x08: 54, 0x09: 166, 0x0a: 859, 0x0b: 201, 0x0c: 93, 0x0d: 230, 0x0e: 71,
 		0x0f: 365, 0x10: 246, 0x11: 208,
 	}


### PR DESCRIPTION
## What

Lower the **default** Unzen modexp precompile zk-gas multiplier from `923` to `154` in `core/vm/taiko_zk_gas_unzen.go`. Mirrors the spec correction in [taikoxyz/taiko-mono#21754](https://github.com/taikoxyz/taiko-mono/pull/21754) (`docs(protocol): update modexp zk gas multiplier to 154`).

## Why

Osaka raised modexp's EVM gas cost ~6× for the worst-case input, but the zk-gas proving-time slopes were benchmarked on **pre-Osaka** gas pricing. That over-estimated modexp's per-gas proving time by 6×, so the multiplier must be divided by 6: `923 ÷ 6 ≈ 154`. After the change, modexp is no longer the worst-case precompile (`point_evaluation@859` is).

## Scope — Masaya stays frozen

Only the **default** schedule (`unzenPrecompileMultipliers()`, used by Devnet/Internal/Hoodi/Mainnet) changes. The frozen Masaya schedule (`masayaUnzenPrecompileMultipliers()`) keeps modexp at `1363`: Masaya already finalized Unzen blocks whose zk-gas total is committed to the header `difficulty` field, so its multipliers can never change without breaking consensus. This is the same freeze shape as the recent recalibration PRs (#564–#567).

Changing the default is safe because no network running it has finalized Unzen blocks yet (Hoodi has Unzen disabled per #562; Mainnet has not activated).

## Changes

- `core/vm/taiko_zk_gas_unzen.go`: default modexp `923` → `154`.
- `core/vm/taiko_zk_gas_test.go`, `core/vm/taiko_zk_gas_unzen_test.go`: update the assertions/table/comment that pin the default modexp value. Masaya's `1363` assertions are untouched, and the Masaya↔default divergence guard still holds (`154 ≠ 1363`).

## Testing

- `go build ./...` — clean
- `go test ./core/vm/...` — pass
- `go test ./core/...` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)