### PR TITLE
fix(vm): charge zk gas for stack-validation and not-activated failures to mirror REVM

### DIFF
--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -199,8 +199,27 @@ func (evm *EVM) Run(contract *Contract, input []byte, readOnly bool) (ret []byte
 		cost = operation.constantGas // For tracing
 		// Validate stack
 		if sLen := stack.len(); sLen < operation.minStack {
+			// CHANGE(taiko): REVM deducts the instruction-table static gas in
+			// step() before the instruction body pops the stack, so a stack
+			// underflow still charges the static gas as zk gas (or all
+			// remaining frame gas when even the static charge cannot be paid).
+			if evm.zkGasTracker != nil && evm.zkGasErr == nil {
+				evm.zkGasTracker.Begin(evm.depth, byte(op), gasBefore)
+				if zkErr := evm.zkGasTracker.FinishAndCharge(evm.depth, zkGasPreExecutionGasAfter(op, gasBefore)); zkErr != nil {
+					evm.setZkGasErr()
+					return nil, ErrZkGasLimitExceeded
+				}
+			}
 			return nil, &ErrStackUnderflow{stackLen: sLen, required: operation.minStack}
 		} else if sLen > operation.maxStack {
+			// CHANGE(taiko): same REVM static-gas mirror as the underflow path.
+			if evm.zkGasTracker != nil && evm.zkGasErr == nil {
+				evm.zkGasTracker.Begin(evm.depth, byte(op), gasBefore)
+				if zkErr := evm.zkGasTracker.FinishAndCharge(evm.depth, zkGasPreExecutionGasAfter(op, gasBefore)); zkErr != nil {
+					evm.setZkGasErr()
+					return nil, ErrZkGasLimitExceeded
+				}
+			}
 			return nil, &ErrStackOverflow{stackLen: sLen, limit: operation.maxStack}
 		}
 		// for tracing: this gas consumption event is emitted below in the debug section.

--- a/core/vm/taiko_zk_gas_runtime.go
+++ b/core/vm/taiko_zk_gas_runtime.go
@@ -18,6 +18,8 @@ import (
 // here but 0 in REVM's table), and REVM additionally ships Amsterdam-gated
 // opcodes (SLOTNUM, DUPN, SWAPN, EXCHANGE) that go-ethereum treats as
 // undefined. Opcodes unknown to REVM's table stay at 0.
+// AI prompt: When upgrading revm, regenerate this table from the new
+// revm-interpreter instruction table for the fork Unzen maps to.
 var zkGasRevmStaticGas = [256]uint64{
 	ADD:        3,
 	MUL:        5,
@@ -143,6 +145,8 @@ func zkGasPreExecutionGasAfter(op OpCode, gasBefore uint64) uint64 {
 // go-ethereum treats them as undefined opcodes and charges no gas, but REVM
 // deducts their table static gas in step() before the instruction halts with
 // NotActivated, so zk gas metering must charge them the same way.
+// AI prompt: When upgrading revm, update this list from the fork-gated opcodes
+// present in REVM's instruction table but not activated for Unzen.
 func isRevmNotActivatedOpcode(op OpCode) bool {
 	switch byte(op) {
 	case 0x4b, 0xe6, 0xe7, 0xe8: // SLOTNUM, DUPN, SWAPN, EXCHANGE (Amsterdam)

--- a/core/vm/taiko_zk_gas_runtime.go
+++ b/core/vm/taiko_zk_gas_runtime.go
@@ -1,10 +1,156 @@
 package vm
 
 import (
+	"errors"
+
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/uint256"
 )
+
+// CHANGE(taiko): zkGasRevmStaticGas mirrors the static gas REVM's instruction
+// table deducts in Interpreter::step before the instruction body runs
+// (revm-interpreter 35.0.1 instruction_table_gas_changes_spec, with the
+// BERLIN repricing applied; Unzen maps to OSAKA). go-ethereum's own
+// constantGas values cannot stand in for these: go-ethereum classifies
+// several base costs as dynamic gas (SLOAD, EXP, LOG0-LOG4) or as constant
+// gas REVM charges inside the instruction body (CREATE/CREATE2 carry 32000
+// here but 0 in REVM's table), and REVM additionally ships Amsterdam-gated
+// opcodes (SLOTNUM, DUPN, SWAPN, EXCHANGE) that go-ethereum treats as
+// undefined. Opcodes unknown to REVM's table stay at 0.
+var zkGasRevmStaticGas = [256]uint64{
+	ADD:        3,
+	MUL:        5,
+	SUB:        3,
+	DIV:        5,
+	SDIV:       5,
+	MOD:        5,
+	SMOD:       5,
+	ADDMOD:     8,
+	MULMOD:     8,
+	EXP:        10,
+	SIGNEXTEND: 5,
+
+	LT:     3,
+	GT:     3,
+	SLT:    3,
+	SGT:    3,
+	EQ:     3,
+	ISZERO: 3,
+	AND:    3,
+	OR:     3,
+	XOR:    3,
+	NOT:    3,
+	BYTE:   3,
+	SHL:    3,
+	SHR:    3,
+	SAR:    3,
+	CLZ:    5,
+
+	KECCAK256: 30,
+
+	ADDRESS:        2,
+	BALANCE:        100,
+	ORIGIN:         2,
+	CALLER:         2,
+	CALLVALUE:      2,
+	CALLDATALOAD:   3,
+	CALLDATASIZE:   2,
+	CALLDATACOPY:   3,
+	CODESIZE:       2,
+	CODECOPY:       3,
+	GASPRICE:       2,
+	EXTCODESIZE:    100,
+	EXTCODECOPY:    100,
+	RETURNDATASIZE: 2,
+	RETURNDATACOPY: 3,
+	EXTCODEHASH:    100,
+
+	BLOCKHASH:   20,
+	COINBASE:    2,
+	TIMESTAMP:   2,
+	NUMBER:      2,
+	DIFFICULTY:  2,
+	GASLIMIT:    2,
+	CHAINID:     2,
+	SELFBALANCE: 5,
+	BASEFEE:     2,
+	BLOBHASH:    3,
+	BLOBBASEFEE: 2,
+	0x4b:        2, // SLOTNUM (Amsterdam, EIP-7843)
+
+	POP:      2,
+	MLOAD:    3,
+	MSTORE:   3,
+	MSTORE8:  3,
+	SLOAD:    100,
+	JUMP:     8,
+	JUMPI:    10,
+	PC:       2,
+	MSIZE:    2,
+	GAS:      2,
+	JUMPDEST: 1,
+	TLOAD:    100,
+	TSTORE:   100,
+	MCOPY:    3,
+	PUSH0:    2,
+
+	PUSH1: 3, PUSH2: 3, PUSH3: 3, PUSH4: 3, PUSH5: 3, PUSH6: 3, PUSH7: 3, PUSH8: 3,
+	PUSH9: 3, PUSH10: 3, PUSH11: 3, PUSH12: 3, PUSH13: 3, PUSH14: 3, PUSH15: 3, PUSH16: 3,
+	PUSH17: 3, PUSH18: 3, PUSH19: 3, PUSH20: 3, PUSH21: 3, PUSH22: 3, PUSH23: 3, PUSH24: 3,
+	PUSH25: 3, PUSH26: 3, PUSH27: 3, PUSH28: 3, PUSH29: 3, PUSH30: 3, PUSH31: 3, PUSH32: 3,
+
+	DUP1: 3, DUP2: 3, DUP3: 3, DUP4: 3, DUP5: 3, DUP6: 3, DUP7: 3, DUP8: 3,
+	DUP9: 3, DUP10: 3, DUP11: 3, DUP12: 3, DUP13: 3, DUP14: 3, DUP15: 3, DUP16: 3,
+
+	SWAP1: 3, SWAP2: 3, SWAP3: 3, SWAP4: 3, SWAP5: 3, SWAP6: 3, SWAP7: 3, SWAP8: 3,
+	SWAP9: 3, SWAP10: 3, SWAP11: 3, SWAP12: 3, SWAP13: 3, SWAP14: 3, SWAP15: 3, SWAP16: 3,
+
+	LOG0: 375,
+	LOG1: 375,
+	LOG2: 375,
+	LOG3: 375,
+	LOG4: 375,
+
+	0xe6: 3, // DUPN (Amsterdam, EIP-663)
+	0xe7: 3, // SWAPN (Amsterdam, EIP-663)
+	0xe8: 3, // EXCHANGE (Amsterdam, EIP-663)
+
+	CALL:         100,
+	CALLCODE:     100,
+	DELEGATECALL: 100,
+	STATICCALL:   100,
+	SELFDESTRUCT: 5000,
+}
+
+// CHANGE(taiko): zkGasPreExecutionGasAfter mirrors REVM's callback-visible gas
+// for opcodes that fail before go-ethereum deducts any gas. REVM charges the
+// instruction-table static gas in step() before the instruction body runs, so
+// a stack underflow/overflow (or the not-activated halt of an opcode REVM
+// ships but Unzen does not enable) still surfaces a net delta of the table's
+// static gas — or all remaining frame gas when even the static charge cannot
+// be paid, because REVM's halt_oog spends everything.
+func zkGasPreExecutionGasAfter(op OpCode, gasBefore uint64) uint64 {
+	staticGas := zkGasRevmStaticGas[op]
+	if gasBefore < staticGas {
+		return 0
+	}
+	return gasBefore - staticGas
+}
+
+// CHANGE(taiko): isRevmNotActivatedOpcode reports opcodes that REVM ships in
+// its instruction table behind a fork gate Unzen (OSAKA) does not enable.
+// go-ethereum treats them as undefined opcodes and charges no gas, but REVM
+// deducts their table static gas in step() before the instruction halts with
+// NotActivated, so zk gas metering must charge them the same way.
+func isRevmNotActivatedOpcode(op OpCode) bool {
+	switch byte(op) {
+	case 0x4b, 0xe6, 0xe7, 0xe8: // SLOTNUM, DUPN, SWAPN, EXCHANGE (Amsterdam)
+		return true
+	default:
+		return false
+	}
+}
 
 // CHANGE(taiko): zkGasPendingStep stores the in-flight opcode state for one EVM depth.
 type zkGasPendingStep struct {
@@ -248,6 +394,13 @@ func zkGasStepGasAfter(op OpCode, err error, gasBefore, gasAfter uint64) uint64 
 	}
 	if err == ErrWriteProtection && op >= LOG0 && op <= LOG4 && gasBefore >= params.LogGas {
 		return gasBefore - params.LogGas
+	}
+	// Opcodes REVM ships behind a fork gate Unzen does not enable execute as
+	// undefined opcodes here (no gas movement), but REVM deducts their table
+	// static gas before halting with NotActivated.
+	var invalidOpcode *ErrInvalidOpCode
+	if errors.As(err, &invalidOpcode) && isRevmNotActivatedOpcode(op) {
+		return zkGasPreExecutionGasAfter(op, gasBefore)
 	}
 	return gasAfter
 }

--- a/core/vm/taiko_zk_gas_runtime_test.go
+++ b/core/vm/taiko_zk_gas_runtime_test.go
@@ -930,3 +930,76 @@ func (c *zkGasTraceCollector) isPrecompile(addr common.Address) bool {
 	_, ok := c.precompiles[addr]
 	return ok
 }
+
+// CHANGE(taiko): TestUnzenZkGas_PreExecutionFailuresMirrorRevmStaticGas pins
+// the zk gas charged for opcodes that fail before go-ethereum deducts any
+// gas (stack underflow/overflow and REVM's not-activated opcodes). REVM
+// deducts its instruction-table static gas in step() before the instruction
+// body runs, so these steps must still charge static-gas zk gas. Every
+// expected value below was probed against alethia-reth under the Unzen
+// schedule.
+func TestUnzenZkGas_PreExecutionFailuresMirrorRevmStaticGas(t *testing.T) {
+	push0Overflow := make([]byte, 1025)
+	for i := range push0Overflow {
+		push0Overflow[i] = byte(PUSH0)
+	}
+
+	tests := []struct {
+		name      string
+		code      []byte
+		gas       uint64
+		wantZkGas uint64
+	}{
+		// 3 static * 19 multiplier.
+		{"add stack underflow", []byte{byte(ADD)}, 100_000, 57},
+		// REVM SLOAD static gas is 100 post-Berlin (go-ethereum carries it as dynamic gas): 100 * 3.
+		{"sload stack underflow", []byte{byte(SLOAD)}, 100_000, 300},
+		// REVM LOG0 static gas is 375 (go-ethereum carries it as dynamic gas): 375 * 3.
+		{"log0 stack underflow", []byte{byte(LOG0)}, 100_000, 1125},
+		// REVM EXP static gas is 10 (go-ethereum carries it as dynamic gas): 10 * 21.
+		{"exp stack underflow", []byte{byte(EXP)}, 100_000, 210},
+		// REVM CREATE static gas is 0 (the 32000 is charged inside the instruction body).
+		{"create stack underflow", []byte{byte(CREATE)}, 100_000, 0},
+		// 3 static * 31 multiplier.
+		{"swap1 stack underflow", []byte{byte(SWAP1)}, 100_000, 93},
+		// Static gas exceeds the 2 gas remaining, so REVM hits OOG first and
+		// spends everything: 2 * 19.
+		{"add stack underflow with unpayable static gas", []byte{byte(ADD)}, 2, 38},
+		// DUPN halts NotActivated in REVM after its 3 static gas is deducted;
+		// the fail-safe multiplier applies: 3 * 65535.
+		{"dupn not activated", []byte{0xe6}, 100_000, 196_605},
+		// SLOTNUM static gas is 2: 2 * 65535.
+		{"slotnum not activated", []byte{0x4b}, 100_000, 131_070},
+		// 1024 successful PUSH0 steps plus the overflowing one all charge 2 * 13.
+		{"push0 stack overflow", push0Overflow, 1_000_000, 26_650},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			meter := NewZkGasMeter(&UnzenZkGasSchedule)
+			contractAddr := common.HexToAddress("0x1000000000000000000000000000000000000000")
+
+			rules := params.MergedTestChainConfig.Rules(big.NewInt(1), true, 1)
+			statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+			statedb.CreateAccount(contractAddr)
+			statedb.SetCode(contractAddr, tt.code, tracing.CodeChangeUnspecified)
+			statedb.Finalise(true)
+
+			evm := NewEVM(BlockContext{
+				CanTransfer: func(StateDB, common.Address, *uint256.Int) bool { return true },
+				Transfer:    func(StateDB, common.Address, common.Address, *uint256.Int, *params.Rules) {},
+				BlockNumber: big.NewInt(1),
+				Time:        1,
+				Random:      &common.Hash{},
+			}, statedb, params.MergedTestChainConfig, Config{ZkGasMeter: meter})
+			statedb.Prepare(rules, common.Address{}, common.Address{}, &contractAddr, ActivePrecompiles(rules), nil)
+
+			if _, _, err := evm.Call(common.Address{}, contractAddr, nil, tt.gas, new(uint256.Int)); err == nil {
+				t.Fatalf("Call succeeded, want a pre-execution failure")
+			}
+			if got := meter.TxZkGasUsed(); got != tt.wantZkGas {
+				t.Fatalf("TxZkGasUsed = %d, want %d", got, tt.wantZkGas)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

A cross-client audit of the Unzen zk gas implementation against alethia-reth found one consensus-relevant divergence: **opcodes that fail before go-ethereum deducts any gas were charged no zk gas, while REVM charges them its instruction-table static gas.**

REVM deducts the table static gas in `Interpreter::step` *before* the instruction body runs; the stack pops happen inside the instruction and halt without spending. go-ethereum validates `minStack`/`maxStack` *before* deducting anything and returned from the interpreter loop without charging. Concretely (probed values, Unzen schedule):

| case | alethia-reth | taiko-geth (before) |
|---|---|---|
| `ADD` on empty stack | 57 (3 × 19) | 0 |
| `SLOAD` on empty stack | 300 (100 × 3) | 0 |
| `LOG0` on empty stack | 1125 (375 × 3) | 0 |
| `ADD` on empty stack, 2 gas left | 38 (REVM OOG spends all: 2 × 19) | 0 |
| `PUSH0` past the 1024 stack limit | 26 (2 × 13) for the failing step | 0 |
| `0xE6` DUPN (Amsterdam-gated in REVM) | 196,605 (3 × 65535 fail-safe) | 0 |
| `0x4B` SLOTNUM (Amsterdam-gated in REVM) | 131,070 (2 × 65535 fail-safe) | 0 |

Since the finalized block zk gas is the Unzen `header.difficulty` and both clients hard-fail imports on mismatch, any block containing a transaction that hits one of these halts (trivially constructible — a one-byte `0x01` contract suffices) splits the two clients.

## Fix

- Add `zkGasRevmStaticGas`, a mirror of the static gas REVM's instruction table deducts in `step()` (revm-interpreter 35.0.1, `instruction_table_gas_changes_spec` with the BERLIN repricing; Unzen maps to OSAKA). go-ethereum's own `constantGas` cannot stand in: SLOAD/EXP/LOG0-4 carry their base cost as dynamic gas here, CREATE/CREATE2 carry 32000 as constant gas where REVM's table holds 0, and REVM additionally ships the Amsterdam-gated opcodes.
- Charge `min(gasBefore, staticGas)` zk gas on both stack-validation error paths in the interpreter loop (when even the static charge cannot be paid, REVM hits OOG first and `halt_oog` spends everything — so the full remaining frame gas is charged).
- Extend `zkGasStepGasAfter` so the four opcodes REVM ships behind the AMSTERDAM gate (`SLOTNUM`, `DUPN`, `SWAPN`, `EXCHANGE`) charge their REVM static gas: go-ethereum executes them as undefined opcodes with no gas movement, while REVM deducts static gas before halting `NotActivated` (the fail-safe multiplier then applies).

EVM-level consensus (state, gas, receipts) is unaffected — these frames already failed and consumed all gas on both clients; only the zk gas accounting changes.

## Validation

- New `TestUnzenZkGas_PreExecutionFailuresMirrorRevmStaticGas` covers all ten cases above; every expected value was probed against alethia-reth (`TaikoEvmFactory` + Unzen schedule) before being pinned here.
- The rest of the audit found the two implementations identical: opcode/precompile multiplier tables, block limit, tx intrinsic, spawn estimates and semantics, precompile charging, meter arithmetic, truncation rules, and the difficulty validation all match. The existing error-path mirrors (`zkGasStepGasAfter` write-protection cases, `zkGasDynamicOOGGasAfter`, the static-OOG full charge, the `InvalidOperandOOG` static-only charge) were each re-verified against revm-interpreter 35.0.1 sources.
- `go test ./core/vm/` and `go test ./core/ -run "ZkGas|Unzen"` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)