### PR TITLE
feat(taiko_genesis): schedule Hoodi Unzen fork

### DIFF
--- a/core/taiko_genesis.go
+++ b/core/taiko_genesis.go
@@ -29,7 +29,7 @@ var (
 	DevnetUnzenTime  uint64 = 0
 	MasayaUnzenTime  uint64 = 0
 	MainnetUnzenTime uint64 = math.MaxUint64
-	HoodiUnzenTime   uint64 = math.MaxUint64
+	HoodiUnzenTime   uint64 = 1_781_787_600
 )
 
 // TaikoGenesisBlock returns the Taiko network genesis block configs.

--- a/core/taiko_genesis_test.go
+++ b/core/taiko_genesis_test.go
@@ -40,6 +40,51 @@ func TestTaikoGenesisBlock_MasayaActivatesUnzenAtGenesis(t *testing.T) {
 	t.Logf("Masaya genesis hash: %s", genesis.ToBlock().Hash())
 }
 
+func TestTaikoGenesisBlock_HoodiActivatesUnzenAtScheduledTime(t *testing.T) {
+	genesis := TaikoGenesisBlock(params.TaikoHoodiNetworkID.Uint64())
+	cfg := genesis.Config
+	if cfg.ChainID.Cmp(params.TaikoHoodiNetworkID) != 0 {
+		t.Fatalf("ChainID = %v, want %v", cfg.ChainID, params.TaikoHoodiNetworkID)
+	}
+
+	const hoodiUnzenTime uint64 = 1_781_787_600
+	if cfg.UnzenTime == nil {
+		t.Fatalf("UnzenTime is nil, want %d", hoodiUnzenTime)
+	}
+	if got := *cfg.UnzenTime; got != hoodiUnzenTime {
+		t.Fatalf("UnzenTime = %d, want %d", got, hoodiUnzenTime)
+	}
+
+	zeroBlock := big.NewInt(0)
+	before := hoodiUnzenTime - 1
+	if cfg.IsUnzen(before) {
+		t.Fatalf("Hoodi Unzen fork is active at timestamp %d", before)
+	}
+	if !cfg.IsUnzen(hoodiUnzenTime) {
+		t.Fatalf("Hoodi Unzen fork is not active at timestamp %d", hoodiUnzenTime)
+	}
+	if cfg.IsCancun(zeroBlock, before) {
+		t.Fatalf("Hoodi Cancun fork is active at timestamp %d", before)
+	}
+	if !cfg.IsCancun(zeroBlock, hoodiUnzenTime) {
+		t.Fatalf("Hoodi Cancun fork is not active at timestamp %d", hoodiUnzenTime)
+	}
+	if cfg.IsPrague(zeroBlock, before) {
+		t.Fatalf("Hoodi Prague fork is active at timestamp %d", before)
+	}
+	if !cfg.IsPrague(zeroBlock, hoodiUnzenTime) {
+		t.Fatalf("Hoodi Prague fork is not active at timestamp %d", hoodiUnzenTime)
+	}
+	if cfg.IsOsaka(zeroBlock, before) {
+		t.Fatalf("Hoodi Osaka fork is active at timestamp %d", before)
+	}
+	if !cfg.IsOsaka(zeroBlock, hoodiUnzenTime) {
+		t.Fatalf("Hoodi Osaka fork is not active at timestamp %d", hoodiUnzenTime)
+	}
+	t.Logf("Taiko Hoodi chain ID: %d", params.TaikoHoodiNetworkID.Uint64())
+	t.Logf("Taiko Hoodi genesis hash: %s", genesis.ToBlock().Hash())
+}
+
 func TestTaikoGenesisBlock_MasayaDoesNotContaminateMainnetForkTimes(t *testing.T) {
 	TaikoGenesisBlock(params.MasayaDevnetNetworkID.Uint64())
 


### PR DESCRIPTION
## Summary
- Schedule Taiko Hoodi L2 Unzen at 2026-06-18 13:00:00 UTC (`1781787600`).
- Keep the fork wiring scoped to the Taiko Hoodi genesis path and leave generic Ethereum Hoodi config untouched.
- Add a regression that pins Hoodi Unzen/Cancun/Prague/Osaka activation at the scheduled timestamp and inactive just before it.

## Validation
- `go test ./core -run 'TestTaikoGenesisBlock_(Hoodi|Masaya)' -count=1 -v`
- `git diff --check`
- `go test ./core -count=1`

## Notes
- Taiko Hoodi chain ID: `167013`
- Taiko Hoodi genesis hash: `0x8e3d16acf3ecc1fbe80309b04e010b90c9ccb3da14e98536cfe66bb93407d228`
