### PR TITLE
fix(eth): witness system-call caller in debug_executionWitnessForTxList

### DIFF
--- a/eth/taiko_api_debug.go
+++ b/eth/taiko_api_debug.go
@@ -13,11 +13,13 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/stateless"
+	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/holiman/uint256"
 )
 
 // Block-level transaction-list size limits. The raw guard bounds the work of
@@ -288,6 +290,25 @@ func buildTxListWitness(bc *core.BlockChain, block *types.Block, txs types.Trans
 	// Apply post-execution changes (withdrawals / header finalization), then
 	// flush the trie so the witness state-node set is complete.
 	bc.Engine().Finalize(bc, header, statedb, &types.Body{Withdrawals: block.Withdrawals()})
+
+	// CHANGE(taiko): witness the system-call caller account (params.SystemAddress,
+	// 0xff..fe). EVM.Call skips the value transfer for system calls (see
+	// core/vm/evm.go), so the caller account is never loaded during the EIP-4788 /
+	// EIP-2935 / EIP-7002 / EIP-7251 system calls and its account-trie path never
+	// enters the witness. This node's own stateless re-execution skips the caller
+	// too, so the gap is invisible to a state-root self-consistency check — but a
+	// cross-client stateless executor that loads the system caller during those
+	// system calls cannot resolve the account without its account-trie proof (and
+	// key preimage). A zero-value balance add loads the account (recording the key)
+	// and, via empty-account clearing in IntermediateRoot, walks its account-trie
+	// path (recording the proof nodes) without changing the post-state root. Only
+	// done when a system call actually ran, so the witness matches cross-client
+	// contents exactly.
+	if block.BeaconRoot() != nil ||
+		config.IsPrague(block.Number(), block.Time()) ||
+		config.IsVerkle(block.Number(), block.Time()) {
+		statedb.AddBalance(params.SystemAddress, uint256.NewInt(0), tracing.BalanceChangeUnspecified)
+	}
 	statedb.IntermediateRoot(true)
 
 	return statedb.Witness(), committed, nil

--- a/eth/taiko_api_debug_integration_test.go
+++ b/eth/taiko_api_debug_integration_test.go
@@ -2,6 +2,7 @@ package eth
 
 import (
 	"context"
+	"encoding/binary"
 	"math/big"
 	"testing"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/ethereum/go-ethereum/trie"
 )
 
 // txListWitnessTestChain builds an in-memory chain of `n` blocks. Block bodies
@@ -332,6 +334,133 @@ func TestBuildTxListWitnessAppliesPostExecutionSystemCalls(t *testing.T) {
 	// reproduce the canonical post-state root. This exercises the full
 	// pre-execution + transaction replay + post-execution path and fails if the
 	// witness omits state the canonical execution touched.
+	hdr := block.Header()
+	hdr.Root = common.Hash{}
+	hdr.ReceiptHash = common.Hash{}
+	stateless := types.NewBlockWithHeader(hdr).WithBody(*block.Body())
+	got, _, err := core.ExecuteStateless(context.Background(), bc.Config(), vm.Config{}, stateless, witness)
+	if err != nil {
+		t.Fatalf("ExecuteStateless: %v", err)
+	}
+	if got != block.Root() {
+		t.Fatalf("state root mismatch: got %s want %s", got, block.Root())
+	}
+}
+
+// txListWitnessDeepPragueChain builds a Prague-active Taiko chain whose genesis
+// funds many extra accounts, so the account trie is deep enough that the
+// SystemAddress exclusion proof spans multiple trie nodes (not just the root).
+// This is what makes the "missing system-caller node" regression observable: a
+// shallow trie hides it because the root node alone proves the exclusion.
+func txListWitnessDeepPragueChain(t *testing.T, extraAccounts int) (*core.BlockChain, []*types.Block) {
+	t.Helper()
+	key, _ := crypto.GenerateKey()
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+	dst := common.HexToAddress("0x00000000000000000000000000000000deadbeef")
+
+	cfg := *params.MergedTestChainConfig // Prague-active (PragueTime == 0)
+	cfg.Taiko = true
+	cfg.ChainID = big.NewInt(167000)
+
+	alloc := types.GenesisAlloc{
+		addr:                             {Balance: big.NewInt(1e18)},
+		params.BeaconRootsAddress:        {Nonce: 1, Code: params.BeaconRootsCode, Balance: common.Big0},
+		params.HistoryStorageAddress:     {Nonce: 1, Code: params.HistoryStorageCode, Balance: common.Big0},
+		params.WithdrawalQueueAddress:    {Nonce: 1, Code: params.WithdrawalQueueCode, Balance: common.Big0},
+		params.ConsolidationQueueAddress: {Nonce: 1, Code: params.ConsolidationQueueCode, Balance: common.Big0},
+	}
+	for i := range extraAccounts {
+		var a common.Address
+		binary.BigEndian.PutUint64(a[:8], uint64(i+1))
+		a[19] = 0x11
+		alloc[a] = types.Account{Balance: big.NewInt(1)}
+	}
+	gspec := &core.Genesis{Config: &cfg, Alloc: alloc}
+	engine := beacon.New(ethash.NewFaker())
+	db := rawdb.NewMemoryDatabase()
+
+	_, blocks, _ := core.GenerateChainWithGenesis(gspec, engine, 2, func(i int, gen *core.BlockGen) {
+		gen.SetParentBeaconRoot(common.HexToHash("0x00000000000000000000000000000000000000000000000000000000cafebabe"))
+		signer := types.LatestSigner(&cfg)
+		tx0, _ := types.SignTx(types.NewTx(&types.DynamicFeeTx{
+			ChainID: cfg.ChainID, Nonce: gen.TxNonce(addr), GasTipCap: big.NewInt(0),
+			GasFeeCap: gen.BaseFee(), Gas: 100000, To: &dst, Value: big.NewInt(1),
+		}), signer, key)
+		if err := tx0.MarkAsAnchor(); err != nil {
+			t.Fatalf("mark anchor: %v", err)
+		}
+		gen.AddTx(tx0)
+	})
+
+	bc, err := core.NewBlockChain(db, gspec, engine, nil)
+	if err != nil {
+		t.Fatalf("new blockchain: %v", err)
+	}
+	if _, err := bc.InsertChain(blocks); err != nil {
+		t.Fatalf("insert chain: %v", err)
+	}
+	return bc, blocks
+}
+
+// accountProofNodes returns the account-trie proof (list of RLP-encoded nodes)
+// for addr against the state trie rooted at root.
+func accountProofNodes(t *testing.T, bc *core.BlockChain, root common.Hash, addr common.Address) [][]byte {
+	t.Helper()
+	accTrie, err := trie.NewStateTrie(trie.StateTrieID(root), bc.TrieDB())
+	if err != nil {
+		t.Fatalf("open state trie at %s: %v", root, err)
+	}
+	var nodes proofNodeList
+	if err := accTrie.Prove(crypto.Keccak256(addr.Bytes()), &nodes); err != nil {
+		t.Fatalf("prove %s: %v", addr, err)
+	}
+	return nodes
+}
+
+type proofNodeList [][]byte
+
+func (p *proofNodeList) Put(key, value []byte) error { *p = append(*p, value); return nil }
+func (p *proofNodeList) Delete(key []byte) error     { return nil }
+
+// TestBuildTxListWitnessIncludesSystemCallCaller is a regression guard: the
+// system-call caller account (params.SystemAddress, 0xff..fe) must appear in the
+// witness — both its key preimage and every node of its account-trie proof.
+//
+// go-geth skips the value transfer for system calls, so it never loads the system
+// caller and its account-trie path is absent from the witness. go-geth's own
+// stateless re-execution skips it too, so the state-root self-consistency check
+// cannot catch the gap; a cross-client stateless executor that loads the caller
+// during its EIP-4788/2935/7002/7251 system calls fails to resolve the account
+// without those nodes. The deep trie makes the missing nodes observable.
+func TestBuildTxListWitnessIncludesSystemCallCaller(t *testing.T) {
+	bc, blocks := txListWitnessDeepPragueChain(t, 2000)
+	defer bc.Stop()
+	block := blocks[len(blocks)-1]
+	parent := bc.GetHeaderByHash(block.ParentHash())
+
+	// Sanity: the trie must be deep enough that the exclusion proof is more than
+	// the root node, otherwise this test would pass trivially and guard nothing.
+	sysProof := accountProofNodes(t, bc, parent.Root, params.SystemAddress)
+	if len(sysProof) < 2 {
+		t.Fatalf("SystemAddress exclusion proof has %d node(s); need a deeper trie to guard the regression", len(sysProof))
+	}
+
+	witness, _, err := buildTxListWitness(bc, block, block.Transactions(), txListWitnessOptions{})
+	if err != nil {
+		t.Fatalf("buildTxListWitness: %v", err)
+	}
+
+	if _, ok := witness.Keys[string(params.SystemAddress.Bytes())]; !ok {
+		t.Fatalf("system-call caller %s missing from witness keys", params.SystemAddress)
+	}
+	for i, node := range sysProof {
+		if _, ok := witness.State[string(node)]; !ok {
+			t.Fatalf("system-call caller account-trie proof node %d/%d missing from witness state", i+1, len(sysProof))
+		}
+	}
+
+	// The witness must still re-execute statelessly to the canonical root: the
+	// extra system-caller nodes must not have perturbed the post-state.
 	hdr := block.Header()
 	hdr.Root = common.Hash{}
 	hdr.ReceiptHash = common.Hash{}


### PR DESCRIPTION
## Summary

Fixes a gap in `debug_executionWitnessForTxList` (added in #576): the execution witness omitted the **system-call caller account** `params.SystemAddress` (`0xff…fe`). A cross-client stateless executor that consumes the witness (the reth-based witness node / raiko2 prover) failed preflight/stateless validation with a *missing state-trie node for `0xff…fe`* error — observed on proposal 396.

Note: the account was reported as the "blockhash contract", but `0xff…fe` is actually `SystemAddress`, the sender of every EIP-4788 / EIP-2935 / EIP-7002 / EIP-7251 system call — not the history contract (`0x00…2935`).

## Root cause

`EVM.Call` skips the value transfer for system calls:

```go
// core/vm/evm.go
if !syscall {
    evm.Context.Transfer(evm.StateDB, caller, addr, value, &evm.chainRules)
}
```

So go-geth never loads the caller `0xff…fe` during system calls. It therefore never enters the witness — neither its key preimage (`keys`) nor its account-trie exclusion path (`state`).

This stayed invisible because go-geth's own `ExecuteStateless` skips the caller too, so the state-root self-consistency check passed with an incomplete witness. A cross-client executor **does** load the system caller and cannot resolve it without those nodes.

Evidence (deep-trie diagnostic): `SystemAddress` absent from `keys`, and 3/4 of its account-trie exclusion-proof nodes absent from `state`. The existing block-based `debug_executionWitness` produced an identical (incomplete) witness — both go-geth paths omit the caller; the reth witness node is the reference that includes it. The history contract `0x00…2935` was fully covered, since it is a system-call *target* and is loaded normally.

## Fix

In `buildTxListWitness`, before the final `IntermediateRoot`, and only when a system call actually ran:

```go
if block.BeaconRoot() != nil || config.IsPrague(...) || config.IsVerkle(...) {
    statedb.AddBalance(params.SystemAddress, uint256.NewInt(0), tracing.BalanceChangeUnspecified)
}
```

`AddBalance(caller, 0)` loads the account (recording the key preimage), then EIP-158 empty-account clearing during `IntermediateRoot` runs `trie.DeleteAccount(0xff…fe)`, which walks the account-trie path and records the proof nodes. The post-state root is unchanged. This mirrors the *touch-and-clear* a reth/revm system call performs on the caller, so the witness now matches cross-client contents exactly. The gate keeps the witness aligned for blocks with no system calls (the caller is not added when none ran).

The change is confined to `buildTxListWitness`; the existing `debug_executionWitness` and block processing are unaffected.

## Testing

- New `TestBuildTxListWitnessIncludesSystemCallCaller`: builds a deep-trie (2000-account) Prague chain so the caller's exclusion proof spans multiple nodes, then asserts the caller's **key** and **every node of its account-trie proof** are in the witness, and that the witness still re-executes statelessly to the canonical state root. Fails before the fix (reproduces the reported error), passes after.
- All existing tx-list witness tests pass; `go build ./...`, `go vet ./eth/`, and `gofmt` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
