### PR TITLE
fix(eth): witness EIP-2935 BLOCKHASH storage in debug_executionWitnessForTxList

### DIFF
--- a/eth/taiko_api_debug.go
+++ b/eth/taiko_api_debug.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/stateless"
@@ -185,7 +186,24 @@ func buildTxListWitness(bc *core.BlockChain, block *types.Block, txs types.Trans
 	statedb.StartPrefetcher("txlist-witness", witness)
 	defer statedb.StopPrefetcher()
 
-	evm := vm.NewEVM(core.NewEVMBlockContext(header, bc, &header.Coinbase), statedb, config, vm.Config{})
+	// CHANGE(taiko): record the block numbers whose hashes the transactions
+	// resolve via the BLOCKHASH opcode. go-geth serves these from the header
+	// chain and witnesses them as headers, but an EIP-2935 stateless executor
+	// resolves them from the HistoryStorage contract's storage. We collect the
+	// numbers here and pull the backing storage slots into the witness below.
+	var blockHashNums []uint64
+	seenBlockHash := make(map[uint64]struct{})
+	evm := vm.NewEVM(core.NewEVMBlockContext(header, bc, &header.Coinbase), statedb, config, vm.Config{
+		Tracer: &tracing.Hooks{
+			OnBlockHashRead: func(number uint64, _ common.Hash) {
+				if _, ok := seenBlockHash[number]; ok {
+					return
+				}
+				seenBlockHash[number] = struct{}{}
+				blockHashNums = append(blockHashNums, number)
+			},
+		},
+	})
 	var zkGasMeter *vm.ZkGasMeter
 	if config.IsUnzen(header.Time) {
 		zkGasMeter = vm.NewZkGasMeter(&vm.UnzenZkGasSchedule)
@@ -308,6 +326,22 @@ func buildTxListWitness(bc *core.BlockChain, block *types.Block, txs types.Trans
 		config.IsPrague(block.Number(), block.Time()) ||
 		config.IsVerkle(block.Number(), block.Time()) {
 		statedb.AddBalance(params.SystemAddress, uint256.NewInt(0), tracing.BalanceChangeUnspecified)
+	}
+
+	// CHANGE(taiko): witness the EIP-2935 HistoryStorage slots backing the block
+	// hashes the transactions resolved via BLOCKHASH. go-geth reads those hashes
+	// from the header chain, so their storage-trie proofs never enter the witness
+	// otherwise; a cross-client stateless executor that resolves BLOCKHASH from
+	// the HistoryStorage contract cannot resolve the account without them. The
+	// slot value equals the block hash go-geth already returned, so this pure
+	// read records the key preimage and loads the storage-trie path without
+	// changing the post-state. EIP-2935 (Prague) stores hash(n) at slot
+	// n % HistoryServeWindow; the served window is a subset of BLOCKHASH's.
+	if config.IsPrague(block.Number(), block.Time()) || config.IsVerkle(block.Number(), block.Time()) {
+		for _, num := range blockHashNums {
+			slot := common.BigToHash(new(big.Int).SetUint64(num % params.HistoryServeWindow))
+			statedb.GetState(params.HistoryStorageAddress, slot)
+		}
 	}
 	statedb.IntermediateRoot(true)
 

--- a/eth/taiko_api_debug_integration_test.go
+++ b/eth/taiko_api_debug_integration_test.go
@@ -525,3 +525,145 @@ func TestBuildTxListWitnessAppliesPreExecutionSystemCalls(t *testing.T) {
 		t.Fatalf("state root mismatch: got %s want %s", got, block.Root())
 	}
 }
+
+// storageProofNodes returns the storage-trie proof (RLP nodes) for slot in
+// addr's storage against the state rooted at stateRoot.
+func storageProofNodes(t *testing.T, bc *core.BlockChain, stateRoot common.Hash, addr common.Address, slot common.Hash) [][]byte {
+	t.Helper()
+	accTrie, err := trie.NewStateTrie(trie.StateTrieID(stateRoot), bc.TrieDB())
+	if err != nil {
+		t.Fatalf("open state trie at %s: %v", stateRoot, err)
+	}
+	acct, err := accTrie.GetAccount(addr)
+	if err != nil {
+		t.Fatalf("get account %s: %v", addr, err)
+	}
+	if acct == nil {
+		t.Fatalf("account %s absent from state %s", addr, stateRoot)
+	}
+	stTrie, err := trie.NewStateTrie(trie.StorageTrieID(stateRoot, crypto.Keccak256Hash(addr.Bytes()), acct.Root), bc.TrieDB())
+	if err != nil {
+		t.Fatalf("open storage trie for %s: %v", addr, err)
+	}
+	var nodes proofNodeList
+	if err := stTrie.Prove(crypto.Keccak256(slot.Bytes()), &nodes); err != nil {
+		t.Fatalf("prove slot %s: %v", slot, err)
+	}
+	return nodes
+}
+
+// TestBuildTxListWitnessIncludesBlockhashHistoryStorage is a regression guard:
+// when a transaction resolves a historical block hash via BLOCKHASH, the witness
+// must include the EIP-2935 HistoryStorage (0x00..2935) storage-trie proof for
+// the ring-buffer slot backing that hash.
+//
+// go-geth serves BLOCKHASH from the header chain and witnesses it as headers, so
+// the HistoryStorage slot's storage nodes are absent. go-geth's own stateless
+// re-execution also reads BLOCKHASH from headers, so the state-root
+// self-consistency check cannot catch the gap; a cross-client stateless executor
+// that resolves BLOCKHASH from the HistoryStorage contract fails to resolve its
+// storage trie ("state trie unresolved") without those nodes.
+//
+// BLOCKHASH cannot run during chain generation (no chain context), so the
+// BLOCKHASH transaction is supplied at replay time — exactly how the RPC feeds an
+// explicit tx list to buildTxListWitness.
+func TestBuildTxListWitnessIncludesBlockhashHistoryStorage(t *testing.T) {
+	key, _ := crypto.GenerateKey()
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+	dst := common.HexToAddress("0x00000000000000000000000000000000deadbeef")
+
+	// Contract: PUSH0, BLOCKHASH, PUSH0, SSTORE, STOP => stores blockhash(0).
+	bhContract := common.HexToAddress("0x00000000000000000000000000000000b10c4a54")
+	bhCode := []byte{0x5f, 0x40, 0x5f, 0x55, 0x00}
+
+	cfg := *params.MergedTestChainConfig // Prague-active (PragueTime == 0)
+	cfg.Taiko = true
+	cfg.ChainID = big.NewInt(167000)
+
+	// Deep pre-populated HistoryStorage (slots 100..699) so the slot-0 proof
+	// spans multiple nodes; leaves slots 0/1 fresh for the blocks' own EIP-2935
+	// system calls. A shallow trie would hide the regression behind the root.
+	hist := make(map[common.Hash]common.Hash)
+	for i := 100; i < 700; i++ {
+		var slot, val common.Hash
+		binary.BigEndian.PutUint64(slot[24:], uint64(i))
+		val[0] = 0xab
+		binary.BigEndian.PutUint64(val[24:], uint64(i)+1)
+		hist[slot] = val
+	}
+	gspec := &core.Genesis{
+		Config: &cfg,
+		Alloc: types.GenesisAlloc{
+			addr:                             {Balance: big.NewInt(1e18)},
+			bhContract:                       {Nonce: 1, Code: bhCode, Balance: common.Big0},
+			params.BeaconRootsAddress:        {Nonce: 1, Code: params.BeaconRootsCode, Balance: common.Big0},
+			params.HistoryStorageAddress:     {Nonce: 1, Code: params.HistoryStorageCode, Balance: common.Big0, Storage: hist},
+			params.WithdrawalQueueAddress:    {Nonce: 1, Code: params.WithdrawalQueueCode, Balance: common.Big0},
+			params.ConsolidationQueueAddress: {Nonce: 1, Code: params.ConsolidationQueueCode, Balance: common.Big0},
+		},
+	}
+	engine := beacon.New(ethash.NewFaker())
+	db := rawdb.NewMemoryDatabase()
+
+	_, blocks, _ := core.GenerateChainWithGenesis(gspec, engine, 2, func(i int, gen *core.BlockGen) {
+		gen.SetParentBeaconRoot(common.HexToHash("0x00000000000000000000000000000000000000000000000000000000cafebabe"))
+		signer := types.LatestSigner(&cfg)
+		tx0, _ := types.SignTx(types.NewTx(&types.DynamicFeeTx{
+			ChainID: cfg.ChainID, Nonce: gen.TxNonce(addr), GasTipCap: big.NewInt(0),
+			GasFeeCap: gen.BaseFee(), Gas: 100000, To: &dst, Value: big.NewInt(1),
+		}), signer, key)
+		if err := tx0.MarkAsAnchor(); err != nil {
+			t.Fatalf("mark anchor: %v", err)
+		}
+		gen.AddTx(tx0)
+	})
+
+	bc, err := core.NewBlockChain(db, gspec, engine, nil)
+	if err != nil {
+		t.Fatalf("new blockchain: %v", err)
+	}
+	defer bc.Stop()
+	if _, err := bc.InsertChain(blocks); err != nil {
+		t.Fatalf("insert chain: %v", err)
+	}
+
+	block := blocks[len(blocks)-1] // block 2; parent = block 1 (addr nonce == 1)
+	parent := bc.GetHeaderByHash(block.ParentHash())
+
+	// BLOCKHASH(0) reads HistoryStorage slot 0. Block 2's own EIP-2935 system
+	// call writes slot 1, so slot 0 enters the witness only if the BLOCKHASH read
+	// path does. Sanity-check the proof is multi-node so this guards something.
+	var slot common.Hash // slot 0
+	stProof := storageProofNodes(t, bc, parent.Root, params.HistoryStorageAddress, slot)
+	if len(stProof) < 2 {
+		t.Fatalf("HistoryStorage slot-0 proof has %d node(s); need a deeper trie to guard the regression", len(stProof))
+	}
+
+	signer := types.LatestSigner(&cfg)
+	anchor, _ := types.SignTx(types.NewTx(&types.DynamicFeeTx{
+		ChainID: cfg.ChainID, Nonce: 1, GasTipCap: big.NewInt(0),
+		GasFeeCap: block.BaseFee(), Gas: 100000, To: &dst, Value: big.NewInt(1),
+	}), signer, key)
+	callBH, _ := types.SignTx(types.NewTx(&types.DynamicFeeTx{
+		ChainID: cfg.ChainID, Nonce: 2, GasTipCap: big.NewInt(0),
+		GasFeeCap: block.BaseFee(), Gas: 100000, To: &bhContract, Value: big.NewInt(0),
+	}), signer, key)
+	replay := types.Transactions{anchor, callBH}
+
+	witness, committed, err := buildTxListWitness(bc, block, replay, txListWitnessOptions{SkipZkGasDifficultyCheck: true})
+	if err != nil {
+		t.Fatalf("buildTxListWitness: %v", err)
+	}
+	if len(committed) != 2 {
+		t.Fatalf("expected anchor + BLOCKHASH tx committed, got %d", len(committed))
+	}
+
+	if _, ok := witness.Keys[string(slot.Bytes())]; !ok {
+		t.Fatalf("HistoryStorage BLOCKHASH slot key preimage missing from witness keys")
+	}
+	for i, node := range stProof {
+		if _, ok := witness.State[string(node)]; !ok {
+			t.Fatalf("HistoryStorage BLOCKHASH slot proof node %d/%d missing from witness state", i+1, len(stProof))
+		}
+	}
+}

--- a/eth/taiko_api_debug_integration_test.go
+++ b/eth/taiko_api_debug_integration_test.go
@@ -666,4 +666,20 @@ func TestBuildTxListWitnessIncludesBlockhashHistoryStorage(t *testing.T) {
 			t.Fatalf("HistoryStorage BLOCKHASH slot proof node %d/%d missing from witness state", i+1, len(stProof))
 		}
 	}
+
+	// Root-preserving: the extra HistoryStorage slot reads are pure reads, so the
+	// witness must still re-execute the block's canonical body to its state root.
+	// (The replay anchor is identical to the block's own tx; the BLOCKHASH-only
+	// extras are a harmless superset for the canonical execution.)
+	hdr := block.Header()
+	hdr.Root = common.Hash{}
+	hdr.ReceiptHash = common.Hash{}
+	stateless := types.NewBlockWithHeader(hdr).WithBody(*block.Body())
+	got, _, err := core.ExecuteStateless(context.Background(), bc.Config(), vm.Config{}, stateless, witness)
+	if err != nil {
+		t.Fatalf("ExecuteStateless: %v", err)
+	}
+	if got != block.Root() {
+		t.Fatalf("state root mismatch: got %s want %s", got, block.Root())
+	}
 }


### PR DESCRIPTION
## Problem

Cross-client stateless re-execution (raiko2 / reth) of a `debug_executionWitnessForTxList` witness fails preflight, reporting the EIP-2935 history contract `0x0000F90827F1C53a10cb7A02335B175320002935` as **"state trie unresolved"** — the witness is missing that account's storage-trie nodes.

This is a follow-up to #578 (which fixed the missing system-call *caller* `0xff…fe`). Same class of bug — an account touched only through an EIP path that go-geth resolves differently from a sparse-trie consumer — but a different access path.

## Root cause

go-geth and an EIP-2935 stateless executor resolve `BLOCKHASH` from **different sources**:

- **go-geth** (`opBlockhash` → `core.GetHashFn`) serves historical block hashes from the **header chain**, and records them in the witness as **headers** (`witness.AddBlockHash`). It never touches the HistoryStorage contract's storage.
- A **cross-client stateless executor** (reth-based) resolves the same `BLOCKHASH` by reading the **HistoryStorage contract storage** — slot `n % 8191` holds `hash(n)`.

The two agree on the *value* (slot `n%8191` is written by block `n+1`'s EIP-2935 system call as `hash(n)`, exactly what `GetHashFn(n)` returns), so there is **no consensus divergence**. But the storage-trie proof for that slot never enters the witness, so the consumer cannot resolve HistoryStorage's storage trie → "state trie unresolved".

The gap was invisible to existing checks because go-geth's own `core.ExecuteStateless` *also* reads `BLOCKHASH` from headers, so the state-root self-consistency test passes on an incomplete witness. It only surfaces in a client that reads the contract.

The EIP-2935 system-call *write* path (slot `(N-1)%8191`) was already witnessed correctly — this is purely the `BLOCKHASH` *read* path, which is why it wasn't caught before.

## Fix

In `buildTxListWitness` (`eth/taiko_api_debug.go`):

1. Attach a minimal tracer (`OnBlockHashRead`) to the replay EVM to record exactly which block numbers the transactions resolve via `BLOCKHASH`. go-geth only fires this for the in-window blocks it actually serves, so the captured set matches what the cross-client executor resolves from the contract.
2. After execution, before the final `IntermediateRoot`, read each backing HistoryStorage slot `n % params.HistoryServeWindow` via `statedb.GetState`. This records the slot's key preimage and loads its storage-trie path into the witness. It is a pure read whose value already equals what go-geth returned, so the **post-state root is unchanged**. Gated on Prague/Verkle (EIP-2935 active).

Bounded work: at most one read per distinct in-window `BLOCKHASH` access (≤ 256).

## Testing

- New `TestBuildTxListWitnessIncludesBlockhashHistoryStorage`: builds a Prague Taiko chain with a deep pre-populated HistoryStorage trie and a contract that runs `BLOCKHASH`, then replays `[anchor, blockhash-call]` and asserts every node of the accessed slot's storage-trie proof — plus its key preimage — is present in the witness. **RED** before the fix (`proof node 2/4 missing`), **GREEN** after.
- #578's `TestBuildTxListWitnessIncludesSystemCallCaller` and all other tx-list witness tests still pass.
- `go build ./...`, `go vet ./eth/`, `gofmt` clean.

To close the loop on the devnet: confirm proposal 396 contains a transaction that executes the `BLOCKHASH` opcode (that is the trigger).
