### PR TITLE
fix(eth): witness extension-split children in execution-witness replay

### DIFF
--- a/eth/taiko_api_debug.go
+++ b/eth/taiko_api_debug.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/ethereum/go-ethereum/triedb/database"
 	"github.com/holiman/uint256"
 )
 
@@ -194,18 +195,34 @@ func buildTxListWitness(bc *core.BlockChain, block *types.Block, txs types.Trans
 	// chain and witnesses them as headers, but an EIP-2935 stateless executor
 	// resolves them from the HistoryStorage contract's storage. We collect the
 	// numbers here and pull the backing storage slots into the witness below.
+	//
+	// CHANGE(taiko): also record which storage slots the replay writes, per
+	// account. The wire-format alignment pass below needs the written slots to
+	// find inserts that split an extension node in the parent trie. State-level
+	// hooks only fire through a hooked state wrapper, so the EVM runs on the
+	// wrapper while the replay keeps operating on the underlying statedb.
 	var blockHashNums []uint64
 	seenBlockHash := make(map[uint64]struct{})
-	evm := vm.NewEVM(core.NewEVMBlockContext(header, bc, &header.Coinbase), statedb, config, vm.Config{
-		Tracer: &tracing.Hooks{
-			OnBlockHashRead: func(number uint64, _ common.Hash) {
-				if _, ok := seenBlockHash[number]; ok {
-					return
-				}
-				seenBlockHash[number] = struct{}{}
-				blockHashNums = append(blockHashNums, number)
-			},
+	storageWrites := make(map[common.Address]map[common.Hash]struct{})
+	hooks := &tracing.Hooks{
+		OnBlockHashRead: func(number uint64, _ common.Hash) {
+			if _, ok := seenBlockHash[number]; ok {
+				return
+			}
+			seenBlockHash[number] = struct{}{}
+			blockHashNums = append(blockHashNums, number)
 		},
+		OnStorageChange: func(addr common.Address, slot common.Hash, _, _ common.Hash) {
+			slots, ok := storageWrites[addr]
+			if !ok {
+				slots = make(map[common.Hash]struct{})
+				storageWrites[addr] = slots
+			}
+			slots[slot] = struct{}{}
+		},
+	}
+	evm := vm.NewEVM(core.NewEVMBlockContext(header, bc, &header.Coinbase), state.NewHookedState(statedb, hooks), config, vm.Config{
+		Tracer: hooks,
 	})
 	var zkGasMeter *vm.ZkGasMeter
 	if config.IsUnzen(header.Time) {
@@ -349,9 +366,9 @@ func buildTxListWitness(bc *core.BlockChain, block *types.Block, txs types.Trans
 	statedb.IntermediateRoot(true)
 
 	// CHANGE(taiko): post-process the collected witness into the cross-client
-	// legacy witness format (storage-trie root nodes, created bytecode, and
-	// existence-filtered keys).
-	if err := alignWitnessForWireFormat(bc, parent.Root, statedb, witness); err != nil {
+	// legacy witness format (storage-trie root nodes, extension-split reveals,
+	// created bytecode, and existence-filtered keys).
+	if err := alignWitnessForWireFormat(bc, parent.Root, statedb, witness, storageWrites); err != nil {
 		return nil, nil, err
 	}
 
@@ -374,7 +391,13 @@ func buildTxListWitness(bc *core.BlockChain, block *types.Block, txs types.Trans
 //     Accounts that were merely probed (absent system contracts, the system
 //     caller) or cleared during finalization carry account-trie exclusion
 //     proofs in state, but no key preimage.
-func alignWitnessForWireFormat(bc *core.BlockChain, parentRoot common.Hash, statedb *state.StateDB, witness *stateless.Witness) error {
+//   - state additionally carries the child node of every extension node that
+//     an insert splits. The insert's exclusion proof ends at the extension, but
+//     the reference sparse-trie mutation cannot restructure the extension
+//     without its child revealed. Deletions need no equivalent: collapsing a
+//     branch resolves the surviving sibling through the witness-tracking trie
+//     reader already.
+func alignWitnessForWireFormat(bc *core.BlockChain, parentRoot common.Hash, statedb *state.StateDB, witness *stateless.Witness, storageWrites map[common.Address]map[common.Hash]struct{}) error {
 	preState, err := bc.StateAt(parentRoot)
 	if err != nil {
 		return fmt.Errorf("failed to open pre-state at %s: %w", parentRoot, err)
@@ -410,12 +433,152 @@ func alignWitnessForWireFormat(bc *core.BlockChain, parentRoot common.Hash, stat
 		if postCodeHash != (common.Hash{}) && postCodeHash != types.EmptyCodeHash && postCodeHash != preState.GetCodeHash(addr) {
 			statedb.GetCode(addr)
 		}
+		// Extension-split reveal for accounts created by the replay.
+		if !preState.Exist(addr) && statedb.Exist(addr) {
+			if err := revealExtensionChild(reader, witness, common.Hash{}, parentRoot, crypto.Keccak256(addr.Bytes())); err != nil {
+				return err
+			}
+		}
 		// Keys carry only accounts existing post-execution.
 		if !statedb.Exist(addr) {
 			witness.DeleteKey(addr.Bytes())
 		}
 	}
+	// Extension-split reveal for storage slots inserted by the replay. Written
+	// slots are cached in the statedb, so the post-value reads stay off the trie
+	// and record nothing new.
+	for addr, slots := range storageWrites {
+		storageRoot := preState.GetStorageRoot(addr)
+		if storageRoot == (common.Hash{}) || storageRoot == types.EmptyRootHash {
+			continue // no parent storage trie, nothing to split
+		}
+		owner := crypto.Keccak256Hash(addr.Bytes())
+		for slot := range slots {
+			if preState.GetState(addr, slot) != (common.Hash{}) {
+				continue // update or delete, not an insert
+			}
+			if statedb.GetState(addr, slot) == (common.Hash{}) {
+				continue // written back to zero, no leaf inserted
+			}
+			if err := revealExtensionChild(reader, witness, owner, storageRoot, crypto.Keccak256(slot.Bytes())); err != nil {
+				return err
+			}
+		}
+	}
 	return nil
+}
+
+// CHANGE(taiko): revealExtensionChild walks the trie rooted at root along the
+// hashed key of an inserted leaf. If the walk diverges inside an extension
+// node's key — the insert splits the extension — the extension's child node is
+// added to the witness state. All other divergence shapes (vacant branch slot,
+// mismatching leaf) need no extra node: the insert's exclusion proof already
+// carries everything the reference sparse-trie mutation resolves.
+func revealExtensionChild(reader database.NodeReader, witness *stateless.Witness, owner common.Hash, root common.Hash, hashedKey []byte) error {
+	keyNibbles := make([]byte, 0, 2*len(hashedKey))
+	for _, b := range hashedKey {
+		keyNibbles = append(keyNibbles, b>>4, b&0x0f)
+	}
+	path := make([]byte, 0, len(keyNibbles))
+	blob, err := reader.Node(owner, path, root)
+	if err != nil || len(blob) == 0 {
+		return fmt.Errorf("trie node %s at root of %s unavailable: %w", root, owner, err)
+	}
+	for {
+		elems, _, err := rlp.SplitList(blob)
+		if err != nil {
+			return fmt.Errorf("malformed trie node at path %x of %s: %w", path, owner, err)
+		}
+		count, err := rlp.CountValues(elems)
+		if err != nil {
+			return fmt.Errorf("malformed trie node at path %x of %s: %w", path, owner, err)
+		}
+		switch count {
+		case 17: // branch node: step into the child at the next key nibble
+			if len(path) >= len(keyNibbles) {
+				return nil
+			}
+			rest := elems
+			for i := 0; i < int(keyNibbles[len(path)]); i++ {
+				if _, _, rest, err = rlp.Split(rest); err != nil {
+					return fmt.Errorf("malformed branch node at path %x of %s: %w", path, owner, err)
+				}
+			}
+			kind, child, _, err := rlp.Split(rest)
+			if err != nil {
+				return fmt.Errorf("malformed branch node at path %x of %s: %w", path, owner, err)
+			}
+			if kind == rlp.List { // embedded child: its bytes are already witnessed with the branch
+				return nil
+			}
+			if len(child) == 0 { // vacant slot: the insert lands here
+				return nil
+			}
+			path = append(path, keyNibbles[len(path)])
+			if blob, err = reader.Node(owner, path, common.BytesToHash(child)); err != nil || len(blob) == 0 {
+				return fmt.Errorf("trie node at path %x of %s unavailable: %w", path, owner, err)
+			}
+		case 2: // short node: leaf or extension
+			compact, rest, err := rlp.SplitString(elems)
+			if err != nil {
+				return fmt.Errorf("malformed short node at path %x of %s: %w", path, owner, err)
+			}
+			nibbles, isLeaf := compactToNibbles(compact)
+			if isLeaf {
+				return nil // divergent or matching leaf: revealed by the exclusion proof
+			}
+			if remaining := keyNibbles[len(path):]; len(remaining) >= len(nibbles) && bytes.Equal(remaining[:len(nibbles)], nibbles) {
+				// Key continues through the extension: follow its child.
+				kind, child, _, err := rlp.Split(rest)
+				if err != nil {
+					return fmt.Errorf("malformed extension node at path %x of %s: %w", path, owner, err)
+				}
+				if kind == rlp.List {
+					return nil // embedded child, witnessed with the extension
+				}
+				path = append(path, nibbles...)
+				if blob, err = reader.Node(owner, path, common.BytesToHash(child)); err != nil || len(blob) == 0 {
+					return fmt.Errorf("trie node at path %x of %s unavailable: %w", path, owner, err)
+				}
+				continue
+			}
+			// The insert splits this extension: reveal its child node.
+			kind, child, _, err := rlp.Split(rest)
+			if err != nil {
+				return fmt.Errorf("malformed extension node at path %x of %s: %w", path, owner, err)
+			}
+			if kind == rlp.List {
+				return nil // embedded child, witnessed with the extension
+			}
+			childPath := append(append([]byte{}, path...), nibbles...)
+			blob, err := reader.Node(owner, childPath, common.BytesToHash(child))
+			if err != nil || len(blob) == 0 {
+				return fmt.Errorf("extension child node at path %x of %s unavailable: %w", childPath, owner, err)
+			}
+			witness.AddState(map[string][]byte{"": blob}, owner)
+			return nil
+		default:
+			return fmt.Errorf("unexpected trie node with %d items at path %x of %s", count, path, owner)
+		}
+	}
+}
+
+// compactToNibbles decodes a hex-prefix (compact) encoded trie path into its
+// nibbles and reports whether the node is a leaf.
+func compactToNibbles(compact []byte) ([]byte, bool) {
+	if len(compact) == 0 {
+		return nil, false
+	}
+	flag := compact[0] >> 4
+	isLeaf := flag >= 2
+	nibbles := make([]byte, 0, 2*len(compact))
+	if flag&1 == 1 { // odd length: first nibble lives in the flag byte
+		nibbles = append(nibbles, compact[0]&0x0f)
+	}
+	for _, b := range compact[1:] {
+		nibbles = append(nibbles, b>>4, b&0x0f)
+	}
+	return nibbles, isLeaf
 }
 
 // CHANGE(taiko): ExecutionWitnessForTxList replays the given RLP transaction

--- a/eth/taiko_api_debug_integration_test.go
+++ b/eth/taiko_api_debug_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/ethash"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/stateless"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -1063,5 +1064,153 @@ func TestBuildTxListWitnessIncludesCreatedContractCode(t *testing.T) {
 
 	if _, ok := witness.Codes[string(runtime)]; !ok {
 		t.Fatalf("bytecode deployed during replay missing from witness codes")
+	}
+}
+
+// txListWitnessStorageShapeChain builds a Taiko chain whose genesis deploys a
+// contract with exactly two storage slots chosen so their hashed keys share a
+// three-nibble prefix: the storage trie is an extension (key c25) into a
+// two-child branch. The contract code stores calldata: SSTORE(calldata[0:32] ->
+// calldata[32:64]), letting replayed transactions insert or delete chosen slots.
+//
+//	slot 3   -> keccak c2575a0e...
+//	slot 497 -> keccak c254b84a...
+func txListWitnessStorageShapeChain(t *testing.T) (*core.BlockChain, []*types.Block, *ecdsa.PrivateKey, common.Address) {
+	t.Helper()
+	key, _ := crypto.GenerateKey()
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+	dst := common.HexToAddress("0x00000000000000000000000000000000deadbeef")
+	contract := common.HexToAddress("0x000000000000000000000000000000005700a6e3")
+
+	cfg := *params.MergedTestChainConfig
+	cfg.Taiko = true
+	cfg.ChainID = big.NewInt(167000)
+
+	val := common.HexToHash("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	gspec := &core.Genesis{
+		Config: &cfg,
+		Alloc: types.GenesisAlloc{
+			addr: {Balance: big.NewInt(1e18)},
+			contract: {
+				Nonce: 1,
+				// PUSH1 32 CALLDATALOAD PUSH1 0 CALLDATALOAD SSTORE STOP
+				Code:    []byte{0x60, 0x20, 0x35, 0x60, 0x00, 0x35, 0x55, 0x00},
+				Balance: common.Big0,
+				Storage: map[common.Hash]common.Hash{
+					common.HexToHash("0x03"):  val, // keccak c2575a0e...
+					common.HexToHash("0x1f1"): val, // keccak c254b84a...
+				},
+			},
+		},
+	}
+	engine := beacon.New(ethash.NewFaker())
+	db := rawdb.NewMemoryDatabase()
+
+	_, blocks, _ := core.GenerateChainWithGenesis(gspec, engine, 2, func(i int, gen *core.BlockGen) {
+		signer := types.LatestSigner(&cfg)
+		tx0, _ := types.SignTx(types.NewTx(&types.DynamicFeeTx{
+			ChainID: cfg.ChainID, Nonce: gen.TxNonce(addr), GasTipCap: big.NewInt(0),
+			GasFeeCap: gen.BaseFee(), Gas: 100000, To: &dst, Value: big.NewInt(1),
+		}), signer, key)
+		if err := tx0.MarkAsAnchor(); err != nil {
+			t.Fatalf("mark anchor: %v", err)
+		}
+		gen.AddTx(tx0)
+	})
+
+	bc, err := core.NewBlockChain(db, gspec, engine, nil)
+	if err != nil {
+		t.Fatalf("new blockchain: %v", err)
+	}
+	if _, err := bc.InsertChain(blocks); err != nil {
+		t.Fatalf("insert chain: %v", err)
+	}
+	return bc, blocks, key, contract
+}
+
+// storeCallTx signs a transaction calling the storage-shape contract with
+// calldata SSTORE(slot -> value).
+func storeCallTx(t *testing.T, bc *core.BlockChain, key *ecdsa.PrivateKey, contract common.Address, baseFee *big.Int, nonce uint64, slot, value common.Hash) *types.Transaction {
+	t.Helper()
+	data := append(slot.Bytes(), value.Bytes()...)
+	signer := types.LatestSigner(bc.Config())
+	tx, err := types.SignTx(types.NewTx(&types.DynamicFeeTx{
+		ChainID: bc.Config().ChainID, Nonce: nonce, GasTipCap: big.NewInt(0),
+		GasFeeCap: baseFee, Gas: 200000, To: &contract, Value: big.NewInt(0), Data: data,
+	}), signer, key)
+	if err != nil {
+		t.Fatalf("sign store tx: %v", err)
+	}
+	return tx
+}
+
+// runStorageShapeReplay replays [anchor, SSTORE(slot->value)] on the shape
+// chain and returns the witness plus the parent-state proof nodes of genesis
+// slot 3 (ext, branch, leaf) and slot 497.
+func runStorageShapeReplay(t *testing.T, slot, value common.Hash) (*stateless.Witness, [][]byte, [][]byte) {
+	t.Helper()
+	bc, blocks, key, contract := txListWitnessStorageShapeChain(t)
+	t.Cleanup(bc.Stop)
+	block := blocks[len(blocks)-1]
+	parent := bc.GetHeaderByHash(block.ParentHash())
+
+	proof3 := storageProofNodes(t, bc, parent.Root, contract, common.HexToHash("0x03"))
+	proof497 := storageProofNodes(t, bc, parent.Root, contract, common.HexToHash("0x1f1"))
+	// Shape guard: ext -> branch -> leaf. A different shape would silently
+	// invalidate what these tests guard.
+	if len(proof3) != 3 || len(proof497) != 3 {
+		t.Fatalf("unexpected storage trie shape: proof lengths %d/%d, want 3/3", len(proof3), len(proof497))
+	}
+
+	call := storeCallTx(t, bc, key, contract, block.BaseFee(), 2, slot, value)
+	replay := types.Transactions{block.Transactions()[0], call}
+	witness, committed, err := buildTxListWitness(bc, block, replay, txListWitnessOptions{SkipZkGasDifficultyCheck: true})
+	if err != nil {
+		t.Fatalf("buildTxListWitness: %v", err)
+	}
+	if len(committed) != 2 {
+		t.Fatalf("expected anchor + store call committed, got %d", len(committed))
+	}
+	return witness, proof3, proof497
+}
+
+// TestBuildTxListWitnessRevealsExtensionChildOnInsert is a regression guard for
+// the cross-client legacy witness format: inserting a storage slot whose hashed
+// key splits an extension node must reveal the extension's child node in the
+// witness state. Slot 241 hashes to c29b...: it shares two nibbles with the
+// genesis extension (key c25) and splits it at its final nibble, so the
+// exclusion proof ends at the extension and the child branch is otherwise
+// absent from the witness.
+func TestBuildTxListWitnessRevealsExtensionChildOnInsert(t *testing.T) {
+	witness, proof3, _ := runStorageShapeReplay(t,
+		common.HexToHash("0xf1"), common.HexToHash("0x01"))
+	if _, ok := witness.State[string(proof3[1])]; !ok {
+		t.Fatalf("extension child branch missing from witness state after extension-splitting insert")
+	}
+}
+
+// TestBuildTxListWitnessRevealsExtensionChildOnMidKeySplitInsert covers the
+// mid-key variant: slot 10 hashes to c65a..., sharing only one nibble with the
+// genesis extension (key c25), so the split leaves a shortened extension in
+// place. The reference sparse-trie mutation still requires the extension's
+// child node revealed.
+func TestBuildTxListWitnessRevealsExtensionChildOnMidKeySplitInsert(t *testing.T) {
+	witness, proof3, _ := runStorageShapeReplay(t,
+		common.HexToHash("0x0a"), common.HexToHash("0x01"))
+	if _, ok := witness.State[string(proof3[1])]; !ok {
+		t.Fatalf("extension child branch missing from witness state after mid-key extension-splitting insert")
+	}
+}
+
+// TestBuildTxListWitnessRevealsCollapseSiblingOnDelete is a regression guard
+// for the cross-client legacy witness format: deleting a storage slot whose
+// removal leaves its parent branch with a single surviving child must reveal
+// that surviving child node (here the untouched leaf of slot 497), because the
+// reference sparse-trie collapse cannot merge the branch without it.
+func TestBuildTxListWitnessRevealsCollapseSiblingOnDelete(t *testing.T) {
+	witness, _, proof497 := runStorageShapeReplay(t,
+		common.HexToHash("0x03"), common.Hash{})
+	if _, ok := witness.State[string(proof497[2])]; !ok {
+		t.Fatalf("surviving sibling leaf missing from witness state after branch-collapsing delete")
 	}
 }


### PR DESCRIPTION
## Why

Follow-up to #581. After redeploying, a live sweep of `debug_executionWitnessForTxList` against the alethia-reth reference showed all four fields set-identical on 17 of 18 sampled devnet blocks — the remaining block (3095) had exactly one reth-only `state` node.

Root cause: the block **inserted a new storage slot** (`pre=0 → post≠0` on `0x1670010000000000000000000000000000000005`) whose hashed key (`b1df…`) splits an extension node (`b1d`, key `9`) in the parent storage trie. The insert's exclusion proof ends at the extension, and go-geth's trie insert re-anchors the extension's child by hash without ever resolving it — but reth's legacy witness reveals the extension's child before restructuring (its sparse-trie mutation, `crates/trie/sparse/src/parallel.rs`, cannot split an extension whose child is blinded), so the child branch (`b1d9`) lands in reth's witness and not geth's.

Deletions turned out to need no equivalent: a new regression test confirms go-geth's trie delete already resolves (and therefore witnesses) the surviving sibling when a branch collapses — matching reth's `remove_leaf` reveal (`"If the remaining child node is not yet revealed then we have to reveal it"`).

## What

`eth/taiko_api_debug.go`:
- `buildTxListWitness` now records the storage slots each replay writes, per account, through a hooked state wrapper (`state.NewHookedState`, the same pattern `eth/tracers` uses) — state-level hooks don't fire through `vm.Config.Tracer` alone.
- `alignWitnessForWireFormat` classifies written slots against the parent state and, for every insert (and every account created by the replay, on the account trie), walks the parent trie along the hashed key with a small `NodeReader`-based walker; when the walk diverges inside an extension's key, the extension's child node is added to the witness. Embedded (inline) children are skipped — they ship inside the parent node.

## Tests

New (watched fail first / behavior pinned):
- `TestBuildTxListWitnessRevealsExtensionChildOnInsert` — split at the extension's final nibble (the exact live shape from block 3095); failed before the fix.
- `TestBuildTxListWitnessRevealsExtensionChildOnMidKeySplitInsert` — mid-key split leaving a shortened extension; failed before the fix.
- `TestBuildTxListWitnessRevealsCollapseSiblingOnDelete` — branch-collapse sibling on slot deletion; passed before the fix (natively covered), kept as a regression guard.

The storage-trie fixtures use slots (3, 497, 241, 10) whose keccak hashes were searched offline to produce the extension/branch shapes deterministically.

Full `./eth`, `./core/stateless`, `./cmd/fetchpayload`, `go build ./...`, and `golangci-lint` pass.

## Verification against live nodes

Post-#581 sweep (blocks 2955–3125, mixed 2/4/12/14/15-tx shapes): `state`/`codes`/`keys`/`headers` set-identical everywhere except the extension-split block this PR fixes. One residual, cosmetic-only difference: reth's `keys` array contains duplicate slot entries (the same slot pushed once per account that accesses it, e.g. the ERC-1967 implementation slot ×6); as sets the fields are identical, and the witness consumer treats them as sets. Byte-exact list equality would need a dedup on the alethia-reth side instead.

The mid-key-split reveal is structurally derived from the reference implementation (extensions store no child hash, so any split must reveal the child) but has not yet been observed live; the rolling live-diff harness will confirm it as such blocks occur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)