### PR TITLE
fix(eth): stop witnessing system-call state the reference never touches

### DIFF
--- a/eth/taiko_api_debug.go
+++ b/eth/taiko_api_debug.go
@@ -23,7 +23,6 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethereum/go-ethereum/triedb/database"
-	"github.com/holiman/uint256"
 )
 
 // Block-level transaction-list size limits. The raw guard bounds the work of
@@ -304,19 +303,12 @@ func buildTxListWitness(bc *core.BlockChain, block *types.Block, txs types.Trans
 		committed = append(committed, tx)
 	}
 
-	// CHANGE(taiko): mirror canonical Prague post-execution system calls (EIP-7002
-	// withdrawal queue, EIP-7251 consolidation queue) so the witness captures their
-	// state accesses before finalization. EIP-6110 deposit-log parsing reads logs
-	// only and touches no state, so it is not needed for the witness.
-	if config.IsPrague(block.Number(), block.Time()) {
-		var requests [][]byte
-		if err := core.ProcessWithdrawalQueue(&requests, evm); err != nil {
-			return nil, nil, fmt.Errorf("post-execution withdrawal queue system call failed: %w", err)
-		}
-		if err := core.ProcessConsolidationQueue(&requests, evm); err != nil {
-			return nil, nil, fmt.Errorf("post-execution consolidation queue system call failed: %w", err)
-		}
-	}
+	// CHANGE(taiko): the EIP-7002 withdrawal-queue and EIP-7251 consolidation-queue
+	// post-execution system calls are deliberately NOT replayed: the cross-client
+	// reference block executor never performs them (its requests are
+	// unconditionally empty), so running them here would witness the queue
+	// contracts' account state that the reference witness does not carry.
+	// EIP-6110 deposit-log parsing reads logs only and touches no state.
 
 	if zkGasMeter != nil && !opts.SkipZkGasDifficultyCheck {
 		recomputed := zkGasMeter.BlockZkGasUsed()
@@ -329,24 +321,13 @@ func buildTxListWitness(bc *core.BlockChain, block *types.Block, txs types.Trans
 	// flush the trie so the witness state-node set is complete.
 	bc.Engine().Finalize(bc, header, statedb, &types.Body{Withdrawals: block.Withdrawals()})
 
-	// CHANGE(taiko): witness the system-call caller account (params.SystemAddress,
-	// 0xff..fe). EVM.Call skips the value transfer for system calls (see
-	// core/vm/evm.go), so the caller account is never loaded during the EIP-4788 /
-	// EIP-2935 / EIP-7002 / EIP-7251 system calls and its account-trie path never
-	// enters the witness. This node's own stateless re-execution skips the caller
-	// too, so the gap is invisible to a state-root self-consistency check — but a
-	// cross-client stateless executor that loads the system caller during those
-	// system calls cannot resolve the account without its account-trie proof (and
-	// key preimage). A zero-value balance add loads the account (recording the key)
-	// and, via empty-account clearing in IntermediateRoot, walks its account-trie
-	// path (recording the proof nodes) without changing the post-state root. Only
-	// done when a system call actually ran, so the witness matches cross-client
-	// contents exactly.
-	if block.BeaconRoot() != nil ||
-		config.IsPrague(block.Number(), block.Time()) ||
-		config.IsVerkle(block.Number(), block.Time()) {
-		statedb.AddBalance(params.SystemAddress, uint256.NewInt(0), tracing.BalanceChangeUnspecified)
-	}
+	// CHANGE(taiko): the system-call caller account (params.SystemAddress,
+	// 0xff..fe) is deliberately NOT witnessed. The reference EVM never loads the
+	// caller for system calls (no pre-execution phase, no value transfer), so its
+	// witness carries neither the caller's key preimage nor any node unique to
+	// the caller's account-trie exclusion path. Touching the caller here would
+	// leak such nodes into the witness on blocks where no other touched account
+	// shares the path prefixes.
 
 	// CHANGE(taiko): witness the EIP-2935 HistoryStorage slots backing the block
 	// hashes the transactions resolved via BLOCKHASH. go-geth reads those hashes

--- a/eth/taiko_api_debug_integration_test.go
+++ b/eth/taiko_api_debug_integration_test.go
@@ -301,15 +301,15 @@ func txListWitnessPragueChain(t *testing.T, n int) (*core.BlockChain, []*types.B
 // EIP-7251 consolidation queue) after replaying transactions, so the witness
 // records both queue system-contract accounts. Without the post-execution system
 // calls neither account is touched and these keys are absent.
-func TestBuildTxListWitnessAppliesPostExecutionSystemCalls(t *testing.T) {
+func TestBuildTxListWitnessSkipsPostExecutionQueueCalls(t *testing.T) {
 	bc, blocks := txListWitnessPragueChain(t, 2)
 	defer bc.Stop()
 	block := blocks[len(blocks)-1]
 
-	// Sanity: the target block must be Prague-active, otherwise postExecution
-	// (and this test) would not exercise the EIP-7002/7251 system calls.
+	// Sanity: the target block must be Prague-active, otherwise this test would
+	// not guard against the EIP-7002/7251 system calls sneaking back in.
 	if !bc.Config().IsPrague(block.Number(), block.Time()) {
-		t.Fatalf("test block is not Prague-active; cannot exercise post-execution system calls")
+		t.Fatalf("test block is not Prague-active; cannot exercise post-execution queue behavior")
 	}
 
 	witness, committed, err := buildTxListWitness(bc, block, block.Transactions(), txListWitnessOptions{})
@@ -320,32 +320,22 @@ func TestBuildTxListWitnessAppliesPostExecutionSystemCalls(t *testing.T) {
 		t.Fatalf("expected all %d txs committed, got %d", len(block.Transactions()), len(committed))
 	}
 
-	// Required regression guard: both Prague post-execution queue system contracts
-	// must appear in the witness key preimages. They are only recorded if the
-	// post-execution system calls ran during witness building.
-	if _, ok := witness.Keys[string(params.WithdrawalQueueAddress.Bytes())]; !ok {
-		t.Fatalf("withdrawal-queue system-contract address missing from witness keys; " +
-			"post-execution EIP-7002 system call was not applied")
+	// The reference block executor never performs the EIP-7002/7251 queue system
+	// calls (its requests are unconditionally empty), so the replay must not
+	// touch the queue contracts either — even when they are deployed. Their
+	// account state entering the witness (previously via key preimages and
+	// account-trie paths) was a cross-client witness difference.
+	//
+	// No stateless re-execution check here: with the queue contracts deployed,
+	// canonical processing does call them, so this witness intentionally lacks
+	// their state. Real Taiko networks do not deploy the queue contracts.
+	if _, ok := witness.Keys[string(params.WithdrawalQueueAddress.Bytes())]; ok {
+		t.Fatalf("withdrawal-queue system-contract address must not appear in witness keys; " +
+			"the reference executor never runs the EIP-7002 system call")
 	}
-	if _, ok := witness.Keys[string(params.ConsolidationQueueAddress.Bytes())]; !ok {
-		t.Fatalf("consolidation-queue system-contract address missing from witness keys; " +
-			"post-execution EIP-7251 system call was not applied")
-	}
-
-	// Self-consistency: re-executing statelessly from the witness alone must
-	// reproduce the canonical post-state root. This exercises the full
-	// pre-execution + transaction replay + post-execution path and fails if the
-	// witness omits state the canonical execution touched.
-	hdr := block.Header()
-	hdr.Root = common.Hash{}
-	hdr.ReceiptHash = common.Hash{}
-	stateless := types.NewBlockWithHeader(hdr).WithBody(*block.Body())
-	got, _, err := core.ExecuteStateless(context.Background(), bc.Config(), vm.Config{}, stateless, witness)
-	if err != nil {
-		t.Fatalf("ExecuteStateless: %v", err)
-	}
-	if got != block.Root() {
-		t.Fatalf("state root mismatch: got %s want %s", got, block.Root())
+	if _, ok := witness.Keys[string(params.ConsolidationQueueAddress.Bytes())]; ok {
+		t.Fatalf("consolidation-queue system-contract address must not appear in witness keys; " +
+			"the reference executor never runs the EIP-7251 system call")
 	}
 }
 
@@ -364,12 +354,12 @@ func txListWitnessDeepPragueChain(t *testing.T, extraAccounts int) (*core.BlockC
 	cfg.Taiko = true
 	cfg.ChainID = big.NewInt(167000)
 
+	// Deliberately no EIP-7002/7251 queue contracts: real Taiko networks do not
+	// deploy them and the replay must not touch them.
 	alloc := types.GenesisAlloc{
-		addr:                             {Balance: big.NewInt(1e18)},
-		params.BeaconRootsAddress:        {Nonce: 1, Code: params.BeaconRootsCode, Balance: common.Big0},
-		params.HistoryStorageAddress:     {Nonce: 1, Code: params.HistoryStorageCode, Balance: common.Big0},
-		params.WithdrawalQueueAddress:    {Nonce: 1, Code: params.WithdrawalQueueCode, Balance: common.Big0},
-		params.ConsolidationQueueAddress: {Nonce: 1, Code: params.ConsolidationQueueCode, Balance: common.Big0},
+		addr:                         {Balance: big.NewInt(1e18)},
+		params.BeaconRootsAddress:    {Nonce: 1, Code: params.BeaconRootsCode, Balance: common.Big0},
+		params.HistoryStorageAddress: {Nonce: 1, Code: params.HistoryStorageCode, Balance: common.Big0},
 	}
 	for i := range extraAccounts {
 		var a common.Address
@@ -424,21 +414,19 @@ type proofNodeList [][]byte
 func (p *proofNodeList) Put(key, value []byte) error { *p = append(*p, value); return nil }
 func (p *proofNodeList) Delete(key []byte) error     { return nil }
 
-// TestBuildTxListWitnessIncludesSystemCallCaller is a regression guard: every
-// node of the system-call caller account's (params.SystemAddress, 0xff..fe)
-// account-trie proof must appear in the witness state.
+// TestBuildTxListWitnessDoesNotWitnessSystemCallCaller is a regression guard:
+// the system-call caller account (params.SystemAddress, 0xff..fe) must not be
+// witnessed. The reference EVM never loads the caller for system calls (no
+// pre-execution phase, no value transfer), so its witness carries neither the
+// caller's key preimage nor any account-trie node unique to the caller's
+// exclusion path. Loading it here (a previous zero-value balance touch did)
+// walked its account-trie path and leaked geth-only nodes into the witness on
+// blocks where no other touched account shares those path prefixes.
 //
-// go-geth skips the value transfer for system calls, so it never loads the system
-// caller and its account-trie path is absent from the witness. go-geth's own
-// stateless re-execution skips it too, so the state-root self-consistency check
-// cannot catch the gap; a cross-client stateless executor that loads the caller
-// during its EIP-4788/2935/7002/7251 system calls fails to resolve the account
-// without those nodes. The deep trie makes the missing nodes observable.
-//
-// The caller's key preimage must NOT appear: the cross-client wire format only
-// carries keys of accounts that exist when execution finishes, and the system
-// caller account never exists.
-func TestBuildTxListWitnessIncludesSystemCallCaller(t *testing.T) {
+// The deep trie makes any leak observable: the exclusion proof spans multiple
+// nodes and its terminal node is unique to the caller's path among the touched
+// accounts.
+func TestBuildTxListWitnessDoesNotWitnessSystemCallCaller(t *testing.T) {
 	bc, blocks := txListWitnessDeepPragueChain(t, 2000)
 	defer bc.Stop()
 	block := blocks[len(blocks)-1]
@@ -457,16 +445,16 @@ func TestBuildTxListWitnessIncludesSystemCallCaller(t *testing.T) {
 	}
 
 	if _, ok := witness.Keys[string(params.SystemAddress.Bytes())]; ok {
-		t.Fatalf("system-call caller %s must not appear in witness keys; only accounts existing post-execution carry key preimages", params.SystemAddress)
+		t.Fatalf("system-call caller %s must not appear in witness keys", params.SystemAddress)
 	}
-	for i, node := range sysProof {
-		if _, ok := witness.State[string(node)]; !ok {
-			t.Fatalf("system-call caller account-trie proof node %d/%d missing from witness state", i+1, len(sysProof))
-		}
+	// The terminal exclusion-proof node lies past the touched accounts'
+	// divergence from the caller's path; witnessing it means the caller account
+	// was loaded during the replay.
+	if _, ok := witness.State[string(sysProof[len(sysProof)-1])]; ok {
+		t.Fatalf("system-call caller exclusion-proof node present in witness state; the caller must not be loaded")
 	}
 
-	// The witness must still re-execute statelessly to the canonical root: the
-	// extra system-caller nodes must not have perturbed the post-state.
+	// The witness must still re-execute statelessly to the canonical root.
 	hdr := block.Header()
 	hdr.Root = common.Hash{}
 	hdr.ReceiptHash = common.Hash{}
@@ -777,12 +765,10 @@ func TestBuildTxListWitnessIncludesBlockhashHistoryStorage(t *testing.T) {
 	gspec := &core.Genesis{
 		Config: &cfg,
 		Alloc: types.GenesisAlloc{
-			addr:                             {Balance: big.NewInt(1e18)},
-			bhContract:                       {Nonce: 1, Code: bhCode, Balance: common.Big0},
-			params.BeaconRootsAddress:        {Nonce: 1, Code: params.BeaconRootsCode, Balance: common.Big0},
-			params.HistoryStorageAddress:     {Nonce: 1, Code: params.HistoryStorageCode, Balance: common.Big0, Storage: hist},
-			params.WithdrawalQueueAddress:    {Nonce: 1, Code: params.WithdrawalQueueCode, Balance: common.Big0},
-			params.ConsolidationQueueAddress: {Nonce: 1, Code: params.ConsolidationQueueCode, Balance: common.Big0},
+			addr:                         {Balance: big.NewInt(1e18)},
+			bhContract:                   {Nonce: 1, Code: bhCode, Balance: common.Big0},
+			params.BeaconRootsAddress:    {Nonce: 1, Code: params.BeaconRootsCode, Balance: common.Big0},
+			params.HistoryStorageAddress: {Nonce: 1, Code: params.HistoryStorageCode, Balance: common.Big0, Storage: hist},
 		},
 	}
 	engine := beacon.New(ethash.NewFaker())


### PR DESCRIPTION
## Why

Post-#582 live sweep (blocks 3162–3180 on the internal devnet, image `sha-667c28c`): all busy blocks are fully set-identical against the alethia-reth reference, but **anchor-only (1-tx) blocks — which had never been comparable before** (older ones always fell outside the geth node's state window) — showed one geth-only `state` node.

Traced it end-to-end: the node is the account-trie branch at path `d`, which lies on the EIP-7002 withdrawal-queue contract's exclusion-proof path (`keccak(0x00000961…7002) = 0xdf86…`). The replay ran the EIP-7002/7251 post-execution queue system calls "to mirror canonical Prague", loading the undeployed queue contracts, and the absent-account prefetch (#580) then witnessed their exclusion paths. The reference block executor **never performs the queue calls** — its `finish()` returns `Requests::default()` unconditionally (alethia-reth `crates/block/src/executor.rs`) — so its witness never contains that state. On busy blocks other touched accounts happen to cover those branch nodes; on anchor-only blocks the difference surfaces.

The same over-inclusion class applies to the zero-value balance touch of the system-call caller `0xff..fe` (added by #578): revm's `run_system_call` skips the pre-execution phase entirely and never loads the caller, and zero-value calls skip the transfer, so the reference witness has no caller-path nodes. Live data confirms reth carries nothing unique there (the reth-only diff count on the affected blocks is zero). The touch was masked so far only because some other touched account happened to share the `f…` path prefix on every sampled block — with ~12 touched accounts per quiet block, that's luck (~50/50 per block), not alignment.

## What

`eth/taiko_api_debug.go` — `buildTxListWitness` no longer:
- runs `ProcessWithdrawalQueue` / `ProcessConsolidationQueue` (EIP-7002/7251);
- touches `params.SystemAddress` with the zero-value `AddBalance`.

The EIP-4788 beacon-root and EIP-2935 parent-block-hash pre-execution system calls stay — the reference performs those. Comments document why the two removals must not come back.

## Tests

Flipped (watched fail first, then pass):
- `TestBuildTxListWitnessSkipsPostExecutionQueueCalls` (was `…AppliesPostExecutionSystemCalls`) — the queue contracts must not be witnessed **even when deployed**; the stateless self-check is dropped there since canonical processing does call deployed queue contracts (real Taiko networks deploy none).
- `TestBuildTxListWitnessDoesNotWitnessSystemCallCaller` (was `…IncludesSystemCallCaller`) — asserts the caller's key and its unique terminal exclusion-proof node are absent, on the deep 2000-account chain where a leak is observable; stateless root reproduction still passes.

Test chains (`txListWitnessDeepPragueChain`, the BLOCKHASH chain) no longer deploy the queue contracts, matching real Taiko networks.

Full `./eth`, `./core/stateless`, `./cmd/fetchpayload`, `go build ./...`, and `golangci-lint` pass.

## Verification

After redeploy I'll re-run the live sweep including anchor-only blocks — expected result: set-identical on all four fields across every block shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)