### PR TITLE
fix(eth): restore system-call caller exclusion proof in execution witness

### DIFF
--- a/eth/taiko_api_debug.go
+++ b/eth/taiko_api_debug.go
@@ -321,13 +321,20 @@ func buildTxListWitness(bc *core.BlockChain, block *types.Block, txs types.Trans
 	// flush the trie so the witness state-node set is complete.
 	bc.Engine().Finalize(bc, header, statedb, &types.Body{Withdrawals: block.Withdrawals()})
 
-	// CHANGE(taiko): the system-call caller account (params.SystemAddress,
-	// 0xff..fe) is deliberately NOT witnessed. The reference EVM never loads the
-	// caller for system calls (no pre-execution phase, no value transfer), so its
-	// witness carries neither the caller's key preimage nor any node unique to
-	// the caller's account-trie exclusion path. Touching the caller here would
-	// leak such nodes into the witness on blocks where no other touched account
-	// shares the path prefixes.
+	// CHANGE(taiko): witness the system-call caller account (params.SystemAddress,
+	// 0xff..fe). The reference EVM touches the caller during the EIP-4788/2935
+	// system calls, so the reference witness carries the account's account-trie
+	// exclusion proof — including its terminal divergence node, which no other
+	// touched account shares (verified against a live reference node). go-geth's
+	// system calls skip the caller entirely, so an explicit read loads the
+	// account and prefetches the exclusion proof. The caller never exists, so
+	// the existence rule keeps its key preimage out of the response, matching
+	// the reference exactly. Only done when a system call actually ran.
+	if block.BeaconRoot() != nil ||
+		config.IsPrague(block.Number(), block.Time()) ||
+		config.IsVerkle(block.Number(), block.Time()) {
+		statedb.GetBalance(params.SystemAddress)
+	}
 
 	// CHANGE(taiko): witness the EIP-2935 HistoryStorage slots backing the block
 	// hashes the transactions resolved via BLOCKHASH. go-geth reads those hashes

--- a/eth/taiko_api_debug_integration_test.go
+++ b/eth/taiko_api_debug_integration_test.go
@@ -414,19 +414,19 @@ type proofNodeList [][]byte
 func (p *proofNodeList) Put(key, value []byte) error { *p = append(*p, value); return nil }
 func (p *proofNodeList) Delete(key []byte) error     { return nil }
 
-// TestBuildTxListWitnessDoesNotWitnessSystemCallCaller is a regression guard:
-// the system-call caller account (params.SystemAddress, 0xff..fe) must not be
-// witnessed. The reference EVM never loads the caller for system calls (no
-// pre-execution phase, no value transfer), so its witness carries neither the
-// caller's key preimage nor any account-trie node unique to the caller's
-// exclusion path. Loading it here (a previous zero-value balance touch did)
-// walked its account-trie path and leaked geth-only nodes into the witness on
-// blocks where no other touched account shares those path prefixes.
+// TestBuildTxListWitnessIncludesSystemCallCaller is a regression guard: the
+// system-call caller account's (params.SystemAddress, 0xff..fe) account-trie
+// exclusion proof must appear in the witness state — every node of it,
+// including the terminal divergence node — while its key preimage must not.
 //
-// The deep trie makes any leak observable: the exclusion proof spans multiple
-// nodes and its terminal node is unique to the caller's path among the touched
-// accounts.
-func TestBuildTxListWitnessDoesNotWitnessSystemCallCaller(t *testing.T) {
+// The reference EVM touches the caller during the EIP-4788/2935 system calls,
+// so the reference witness proves the account's absence (verified against a
+// live reference node: the terminal exclusion node is present there). The
+// caller account never exists, so per the existence rule it carries no key
+// preimage. go-geth's system calls skip the caller entirely, so without an
+// explicit load its exclusion path is missing and the witness under-covers.
+// The deep trie makes the missing nodes observable.
+func TestBuildTxListWitnessIncludesSystemCallCaller(t *testing.T) {
 	bc, blocks := txListWitnessDeepPragueChain(t, 2000)
 	defer bc.Stop()
 	block := blocks[len(blocks)-1]
@@ -447,11 +447,10 @@ func TestBuildTxListWitnessDoesNotWitnessSystemCallCaller(t *testing.T) {
 	if _, ok := witness.Keys[string(params.SystemAddress.Bytes())]; ok {
 		t.Fatalf("system-call caller %s must not appear in witness keys", params.SystemAddress)
 	}
-	// The terminal exclusion-proof node lies past the touched accounts'
-	// divergence from the caller's path; witnessing it means the caller account
-	// was loaded during the replay.
-	if _, ok := witness.State[string(sysProof[len(sysProof)-1])]; ok {
-		t.Fatalf("system-call caller exclusion-proof node present in witness state; the caller must not be loaded")
+	for i, node := range sysProof {
+		if _, ok := witness.State[string(node)]; !ok {
+			t.Fatalf("system-call caller exclusion-proof node %d/%d missing from witness state", i+1, len(sysProof))
+		}
 	}
 
 	// The witness must still re-execute statelessly to the canonical root.


### PR DESCRIPTION
## Why

Post-#583 live sweep (blocks 3175–3204, shapes from 2-tx up to 54-tx): the geth-only queue-contract exclusion nodes are gone as intended — but every block now shows exactly **one reth-only `state` node**, the same 107-byte account-trie leaf.

Traced precisely: the leaf is the **terminal divergence node of the system caller's (`0xff..fe`) account-trie exclusion proof** (`keccak(0xff..fe) = 0xfcbd…`; walking the parent state root through the reference witness goes root → branch `f` → branch `fc` → this leaf, whose key mismatches — proving absence). The reference EVM does touch the caller during the EIP-4788/2935 system calls, so its witness targets the account and carries the exclusion proof (no key preimage, since the account doesn't exist). #583 removed the caller touch together with the queue calls based on reading the reference EVM's system-call path as never loading the caller — the live diff proves that inference wrong for the caller, while confirming it for the queue contracts (no reth-only queue nodes appeared).

The upper proof nodes are shared with other touched accounts' paths; only the terminal leaf is unique to the caller's walk, which is why the gap is exactly one node per block.

## What

`eth/taiko_api_debug.go` — when a system call ran (same fork gate as before), load the caller with a pure `GetBalance` read: the absent-account load prefetches the full exclusion proof into the witness, with no journal side effects (the previous implementation used a zero-value `AddBalance` touch). The existence-based keys rule keeps `0xff..fe` out of the response `keys`, matching the reference. The EIP-7002/7251 queue-call removal from #583 stands.

## Tests

`TestBuildTxListWitnessIncludesSystemCallCaller` restored to reference semantics (watched fail first): every node of the caller's exclusion proof present in `state` — including the terminal node, on the deep 2000-account chain — and no key preimage. `TestBuildTxListWitnessSkipsPostExecutionQueueCalls` still passes. Full `./eth`, lint, and build green.

## Verification

After redeploy I'll re-run the sweep — expected: set-identical on all four fields across every block shape, with the only remaining textual difference being the reference's duplicate `keys` array entries (sets already equal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)