### PR TITLE
chore(vm): align CREATE-family zk-gas spawn and shortfall boundaries

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -669,6 +669,18 @@ func (evm *EVM) create(caller common.Address, code []byte, gas uint64, value *ui
 	if nonce+1 < nonce {
 		return nil, common.Address{}, gas, ErrNonceUintOverflow
 	}
+	// CHANGE(taiko): resolve the pending CREATE-family spawn charge before the
+	// created address is inspected or mutated. The Rust reference EVM charges
+	// the fixed spawn estimate as soon as dispatch commits to opening the
+	// child frame — before its nonce, collision, and account-setup phase — so
+	// failing here must not add any state dependency on the would-be created
+	// account.
+	if zkErr := evm.chargePendingSpawn(); zkErr != nil {
+		if evm.Config.Tracer != nil && evm.Config.Tracer.OnGasChange != nil {
+			evm.Config.Tracer.OnGasChange(gas, 0, tracing.GasChangeCallFailedExecution)
+		}
+		return nil, common.Address{}, 0, zkErr
+	}
 	evm.StateDB.SetNonce(caller, nonce+1, tracing.NonceChangeContractCreator)
 
 	// Charge the contract creation init gas in verkle mode
@@ -740,12 +752,6 @@ func (evm *EVM) create(caller common.Address, code []byte, gas uint64, value *ui
 	// for the initialization code.
 	contract.SetCallCode(common.Hash{}, code)
 	contract.IsDeployment = true
-
-	if err = evm.chargePendingSpawn(); err != nil {
-		evm.StateDB.RevertToSnapshot(snapshot)
-		contract.UseGas(contract.Gas, evm.Config.Tracer, tracing.GasChangeCallFailedExecution)
-		return nil, address, contract.Gas, err
-	}
 
 	ret, err = evm.initNewContract(contract, address)
 	if err != nil && (evm.chainRules.IsHomestead || err != ErrCodeStoreOutOfGas) {

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -205,7 +205,14 @@ func (evm *EVM) Run(contract *Contract, input []byte, readOnly bool) (ret []byte
 			// remaining frame gas when even the static charge cannot be paid).
 			if evm.zkGasTracker != nil && evm.zkGasErr == nil {
 				evm.zkGasTracker.Begin(evm.depth, byte(op), gasBefore)
-				if zkErr := evm.zkGasTracker.FinishAndCharge(evm.depth, zkGasPreExecutionGasAfter(op, gasBefore)); zkErr != nil {
+				gasAfterUnderflow := zkGasPreExecutionGasAfter(op, gasBefore)
+				// CHANGE(taiko): CREATE2 pops its salt only after REVM charges
+				// the initcode and memory costs, so a three-operand stack must
+				// meter those in-body charges instead of the table static gas.
+				if op == CREATE2 && sLen == 3 {
+					gasAfterUnderflow = zkGasCreate2SaltUnderflowGasAfter(evm, stack, mem, gasBefore)
+				}
+				if zkErr := evm.zkGasTracker.FinishAndCharge(evm.depth, gasAfterUnderflow); zkErr != nil {
 					evm.setZkGasErr()
 					return nil, ErrZkGasLimitExceeded
 				}

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -226,7 +226,16 @@ func (evm *EVM) Run(contract *Contract, input []byte, readOnly bool) (ret []byte
 		if contract.Gas < cost {
 			if evm.zkGasTracker != nil && evm.zkGasErr == nil {
 				evm.zkGasTracker.Begin(evm.depth, byte(op), gasBefore)
-				if zkErr := evm.zkGasTracker.FinishAndCharge(evm.depth, 0); zkErr != nil {
+				// CHANGE(taiko): CREATE-family fronts its 32000 base cost as
+				// constant gas here, but REVM only charges that base inside the
+				// instruction after the initcode and memory charges, so this
+				// shortfall must reconstruct REVM's charge order instead of
+				// spending all remaining gas.
+				gasAfterShortfall := uint64(0)
+				if op == CREATE || op == CREATE2 {
+					gasAfterShortfall = zkGasCreateShortfallGasAfter(evm, stack, mem, gasBefore)
+				}
+				if zkErr := evm.zkGasTracker.FinishAndCharge(evm.depth, gasAfterShortfall); zkErr != nil {
 					evm.setZkGasErr()
 					return nil, ErrZkGasLimitExceeded
 				}
@@ -250,7 +259,7 @@ func (evm *EVM) Run(contract *Contract, input []byte, readOnly bool) (ret []byte
 				if overflow {
 					if evm.zkGasTracker != nil && evm.zkGasErr == nil {
 						evm.zkGasTracker.Begin(evm.depth, byte(op), gasBefore)
-						if zkErr := evm.zkGasTracker.FinishAndCharge(evm.depth, gasAfterStatic); zkErr != nil {
+						if zkErr := evm.zkGasTracker.FinishAndCharge(evm.depth, zkGasMemorySizeOverflowGasAfter(evm, op, stack, mem, gasBefore, gasAfterStatic)); zkErr != nil {
 							evm.setZkGasErr()
 							return nil, ErrZkGasLimitExceeded
 						}
@@ -262,7 +271,7 @@ func (evm *EVM) Run(contract *Contract, input []byte, readOnly bool) (ret []byte
 				if memorySize, overflow = math.SafeMul(toWordSize(memSize), 32); overflow {
 					if evm.zkGasTracker != nil && evm.zkGasErr == nil {
 						evm.zkGasTracker.Begin(evm.depth, byte(op), gasBefore)
-						if zkErr := evm.zkGasTracker.FinishAndCharge(evm.depth, gasAfterStatic); zkErr != nil {
+						if zkErr := evm.zkGasTracker.FinishAndCharge(evm.depth, zkGasMemorySizeOverflowGasAfter(evm, op, stack, mem, gasBefore, gasAfterStatic)); zkErr != nil {
 							evm.setZkGasErr()
 							return nil, ErrZkGasLimitExceeded
 						}
@@ -279,6 +288,16 @@ func (evm *EVM) Run(contract *Contract, input []byte, readOnly bool) (ret []byte
 				if evm.zkGasTracker != nil && evm.zkGasErr == nil && errors.Is(err, ErrOutOfGas) {
 					evm.zkGasTracker.Begin(evm.depth, byte(op), gasBefore)
 					if zkErr := evm.zkGasTracker.FinishAndCharge(evm.depth, zkGasDynamicOOGGasAfter(evm, op, stack, mem, memorySize, memoryLastGasCost, gasBefore, gasAfterStatic)); zkErr != nil {
+						evm.setZkGasErr()
+						return nil, ErrZkGasLimitExceeded
+					}
+				}
+				// CHANGE(taiko): a CREATE-family memory cost beyond the uint64
+				// cap halts REVM while preserving the gas left after its
+				// initcode charge, so it must be metered instead of skipped.
+				if evm.zkGasTracker != nil && evm.zkGasErr == nil && (op == CREATE || op == CREATE2) && errors.Is(err, ErrGasUintOverflow) {
+					evm.zkGasTracker.Begin(evm.depth, byte(op), gasBefore)
+					if zkErr := evm.zkGasTracker.FinishAndCharge(evm.depth, zkGasCreateShortfallGasAfter(evm, stack, mem, gasBefore)); zkErr != nil {
 						evm.setZkGasErr()
 						return nil, ErrZkGasLimitExceeded
 					}

--- a/core/vm/taiko_zk_gas_runtime.go
+++ b/core/vm/taiko_zk_gas_runtime.go
@@ -406,6 +406,64 @@ func zkGasCreatePreMemoryCost(evm *EVM, stack *Stack) (uint64, bool) {
 	return zkGasWordCost(stack.Back(2), params.InitCodeWordGas)
 }
 
+// CHANGE(taiko): zkGasCreateShortfallGasAfter mirrors REVM's callback-visible
+// gas for CREATE/CREATE2 steps that fail before go-ethereum reaches the
+// instruction body. go-ethereum fronts the 32000 base cost as constant gas and
+// validates memory sizes before dynamic gas, while REVM charges in instruction
+// order: the static-context check and operand/size validation halt before any
+// charge, the EIP-3860 initcode word cost spends all remaining gas when it
+// cannot be paid, memory expansion halts preserving remaining gas when it
+// cannot be paid, and the trailing base (+ CREATE2 hashing) charge spends all
+// remaining gas.
+func zkGasCreateShortfallGasAfter(evm *EVM, stack *Stack, mem *Memory, gasBefore uint64) uint64 {
+	if evm.readOnly {
+		return gasBefore
+	}
+	size, overflow := stack.Back(2).Uint64WithOverflow()
+	if overflow {
+		return gasBefore
+	}
+	if size == 0 {
+		return 0
+	}
+	var initcodeCost uint64
+	if evm.chainRules.IsShanghai {
+		if size > params.MaxInitCodeSize {
+			return gasBefore
+		}
+		initcodeCost = toWordSize(size) * params.InitCodeWordGas
+	}
+	if gasBefore < initcodeCost {
+		return 0
+	}
+	gasAfterInitcode := gasBefore - initcodeCost
+	memSize, overflow := calcMemSize64(stack.Back(1), stack.Back(2))
+	if overflow {
+		return gasAfterInitcode
+	}
+	alignedMemSize, overflow := math.SafeMul(toWordSize(memSize), 32)
+	if overflow {
+		return gasAfterInitcode
+	}
+	memoryCost, _, _, ok := zkGasMemoryExpansionCost(uint64(mem.Len()), mem.lastGasCost, alignedMemSize)
+	if !ok || gasAfterInitcode < memoryCost {
+		return gasAfterInitcode
+	}
+	return 0
+}
+
+// CHANGE(taiko): zkGasMemorySizeOverflowGasAfter picks the REVM-mirroring
+// charge for memory-size operand overflows. Most opcodes surface these after
+// REVM already deducted its table static gas (matching go-ethereum's
+// constant-gas deduction), but CREATE-family operand overflows halt REVM
+// around its in-body initcode charge instead of the fronted 32000 base cost.
+func zkGasMemorySizeOverflowGasAfter(evm *EVM, op OpCode, stack *Stack, mem *Memory, gasBefore, gasAfterStatic uint64) uint64 {
+	if op == CREATE || op == CREATE2 {
+		return zkGasCreateShortfallGasAfter(evm, stack, mem, gasBefore)
+	}
+	return gasAfterStatic
+}
+
 // CHANGE(taiko): zkGasStepGasAfter mirrors REVM's callback-visible gas delta
 // for cases where go-ethereum performs validation after charging dynamic gas.
 // Static LOG/CREATE write-protection values are derived from observed Rust

--- a/core/vm/taiko_zk_gas_runtime.go
+++ b/core/vm/taiko_zk_gas_runtime.go
@@ -406,50 +406,76 @@ func zkGasCreatePreMemoryCost(evm *EVM, stack *Stack) (uint64, bool) {
 	return zkGasWordCost(stack.Back(2), params.InitCodeWordGas)
 }
 
-// CHANGE(taiko): zkGasCreateShortfallGasAfter mirrors REVM's callback-visible
-// gas for CREATE/CREATE2 steps that fail before go-ethereum reaches the
-// instruction body. go-ethereum fronts the 32000 base cost as constant gas and
-// validates memory sizes before dynamic gas, while REVM charges in instruction
-// order: the static-context check and operand/size validation halt before any
-// charge, the EIP-3860 initcode word cost spends all remaining gas when it
-// cannot be paid, memory expansion halts preserving remaining gas when it
-// cannot be paid, and the trailing base (+ CREATE2 hashing) charge spends all
-// remaining gas.
-func zkGasCreateShortfallGasAfter(evm *EVM, stack *Stack, mem *Memory, gasBefore uint64) uint64 {
+// CHANGE(taiko): zkGasCreateBodyGasAfter reconstructs REVM's in-body
+// CREATE/CREATE2 charge order up to, but not including, the instruction tail
+// that follows the initcode and memory charges. The static-context check and
+// operand/size validation halt before any charge, the EIP-3860 initcode word
+// cost spends all remaining gas when it cannot be paid, and memory expansion
+// halts preserving remaining gas when it cannot be paid. The boolean reports
+// whether REVM reaches that tail with the returned gas still remaining.
+func zkGasCreateBodyGasAfter(evm *EVM, stack *Stack, mem *Memory, gasBefore uint64) (uint64, bool) {
 	if evm.readOnly {
-		return gasBefore
+		return gasBefore, false
 	}
 	size, overflow := stack.Back(2).Uint64WithOverflow()
 	if overflow {
-		return gasBefore
+		return gasBefore, false
 	}
 	if size == 0 {
-		return 0
+		return gasBefore, true
 	}
 	var initcodeCost uint64
 	if evm.chainRules.IsShanghai {
 		if size > params.MaxInitCodeSize {
-			return gasBefore
+			return gasBefore, false
 		}
 		initcodeCost = toWordSize(size) * params.InitCodeWordGas
 	}
 	if gasBefore < initcodeCost {
-		return 0
+		return 0, false
 	}
 	gasAfterInitcode := gasBefore - initcodeCost
 	memSize, overflow := calcMemSize64(stack.Back(1), stack.Back(2))
 	if overflow {
-		return gasAfterInitcode
+		return gasAfterInitcode, false
 	}
 	alignedMemSize, overflow := math.SafeMul(toWordSize(memSize), 32)
 	if overflow {
-		return gasAfterInitcode
+		return gasAfterInitcode, false
 	}
 	memoryCost, _, _, ok := zkGasMemoryExpansionCost(uint64(mem.Len()), mem.lastGasCost, alignedMemSize)
 	if !ok || gasAfterInitcode < memoryCost {
-		return gasAfterInitcode
+		return gasAfterInitcode, false
 	}
-	return 0
+	return gasAfterInitcode - memoryCost, true
+}
+
+// CHANGE(taiko): zkGasCreateShortfallGasAfter mirrors REVM's callback-visible
+// gas for CREATE/CREATE2 steps that fail before go-ethereum reaches the
+// instruction body. go-ethereum fronts the 32000 base cost as constant gas and
+// validates memory sizes before dynamic gas, while REVM charges in instruction
+// order. On every path that funnels here the instruction tail is the trailing
+// base (+ CREATE2 hashing) charge, which cannot be paid and spends all
+// remaining gas.
+func zkGasCreateShortfallGasAfter(evm *EVM, stack *Stack, mem *Memory, gasBefore uint64) uint64 {
+	gasAfter, reachedTail := zkGasCreateBodyGasAfter(evm, stack, mem, gasBefore)
+	if reachedTail {
+		return 0
+	}
+	return gasAfter
+}
+
+// CHANGE(taiko): zkGasCreate2SaltUnderflowGasAfter mirrors REVM's
+// callback-visible gas for a CREATE2 that underflows on its fourth stack
+// operand. REVM pops value, offset, and length first, charges the EIP-3860
+// initcode cost and memory expansion, and only then pops the salt, so this
+// late underflow halts preserving the gas left by those in-body charges and
+// never reaches the trailing base (+ hashing) charge. go-ethereum's up-front
+// stack check fires before any of that and would otherwise meter the step as
+// zero.
+func zkGasCreate2SaltUnderflowGasAfter(evm *EVM, stack *Stack, mem *Memory, gasBefore uint64) uint64 {
+	gasAfter, _ := zkGasCreateBodyGasAfter(evm, stack, mem, gasBefore)
+	return gasAfter
 }
 
 // CHANGE(taiko): zkGasMemorySizeOverflowGasAfter picks the REVM-mirroring

--- a/core/vm/taiko_zk_gas_runtime_test.go
+++ b/core/vm/taiko_zk_gas_runtime_test.go
@@ -1419,3 +1419,111 @@ func TestUnzenZkGas_CreateShortfallInStaticContextChargesNothing(t *testing.T) {
 		t.Fatalf("TxZkGasUsed = %d, want 0 for a static-context CREATE shortfall", got)
 	}
 }
+
+func TestUnzenZkGas_Create2SaltUnderflowMirrorsReferenceChargeOrder(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		code    []byte
+		callGas uint64
+		want    uint64
+	}{
+		{
+			// REVM pops value/offset/length, charges the initcode word cost
+			// (2) and memory expansion (3), and only then underflows popping
+			// the salt with gas preserved.
+			name:    "three operands nonzero length charges initcode and memory",
+			code:    common.Hex2Bytes("602060006000f500"),
+			callGas: 20_000,
+			want:    5,
+		},
+		{
+			// Zero length skips the initcode and memory charges entirely, so
+			// the salt-pop underflow surfaces with nothing charged.
+			name:    "three operands zero length charges nothing",
+			code:    common.Hex2Bytes("600060006000f500"),
+			callGas: 20_000,
+			want:    0,
+		},
+		{
+			// With fewer than three operands REVM underflows on its first
+			// pop, before any charge, matching the static-gas rule.
+			name:    "two operands charge nothing",
+			code:    common.Hex2Bytes("60006000f500"),
+			callGas: 20_000,
+			want:    0,
+		},
+		{
+			// The initcode word cost itself cannot be paid: REVM spends all
+			// remaining gas before reaching the salt pop.
+			name:    "unaffordable initcode cost spends all",
+			code:    common.Hex2Bytes("61c00060006000f500"),
+			callGas: 2_000,
+			want:    1_991,
+		},
+		{
+			// Oversized initcode halts before any charge.
+			name:    "oversized initcode charges nothing",
+			code:    common.Hex2Bytes("61c00160006000f500"),
+			callGas: 20_000,
+			want:    0,
+		},
+		{
+			// Length operand beyond 64 bits halts before any charge.
+			name:    "length overflow charges nothing",
+			code:    common.Hex2Bytes("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff60006000f500"),
+			callGas: 100_000,
+			want:    0,
+		},
+		{
+			// Offset operand beyond 64 bits halts after the initcode charge.
+			name:    "offset overflow charges initcode cost",
+			code:    common.Hex2Bytes("60207fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff6000f500"),
+			callGas: 100_000,
+			want:    2,
+		},
+		{
+			// Memory expansion is unaffordable: REVM halts preserving the
+			// post-initcode gas before reaching the salt pop.
+			name:    "unaffordable memory expansion charges initcode cost",
+			code:    common.Hex2Bytes("602063ffffffff6000f500"),
+			callGas: 20_000,
+			want:    2,
+		},
+		{
+			// Memory expansion cost overflows go-ethereum's cap: same
+			// preserved halt after the initcode charge.
+			name:    "memory cost overflow charges initcode cost",
+			code:    common.Hex2Bytes("6020650100000000006000f500"),
+			callGas: 100_000,
+			want:    2,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			meter, evm := newCreateShortfallEVM(t, tt.code, nil)
+
+			_, _, err := evm.Call(common.Address{}, spawnBoundaryOuterAddr, nil, tt.callGas, new(uint256.Int))
+			if v := (*ErrStackUnderflow)(nil); !errors.As(err, &v) {
+				t.Fatalf("Call err = %v, want stack underflow", err)
+			}
+			if got := meter.TxZkGasUsed(); got != tt.want {
+				t.Fatalf("TxZkGasUsed = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnzenZkGas_Create2SaltUnderflowInStaticContextChargesNothing(t *testing.T) {
+	innerAddr := common.HexToAddress("0x2000000000000000000000000000000000000000")
+	innerCode := common.Hex2Bytes("602060006000f500")
+	meter, evm := newCreateShortfallEVM(t, spawnBoundaryCallCode(STATICCALL, innerAddr), map[common.Address][]byte{
+		innerAddr: innerCode,
+	})
+
+	_, _, err := evm.Call(common.Address{}, spawnBoundaryOuterAddr, nil, 200_000, new(uint256.Int))
+	if err != nil {
+		t.Fatalf("Call returned error: %v", err)
+	}
+	if got := meter.TxZkGasUsed(); got != 0 {
+		t.Fatalf("TxZkGasUsed = %d, want 0 for a static-context CREATE2 salt underflow", got)
+	}
+}

--- a/core/vm/taiko_zk_gas_runtime_test.go
+++ b/core/vm/taiko_zk_gas_runtime_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/uint256"
 )
@@ -1177,5 +1178,244 @@ func TestUnzenZkGas_PreExecutionFailuresMirrorRevmStaticGas(t *testing.T) {
 				t.Fatalf("TxZkGasUsed = %d, want %d", got, tt.wantZkGas)
 			}
 		})
+	}
+}
+
+// createAccountReadRecorder counts account-level reads per address so tests can
+// prove which accounts an execution path inspected.
+type createAccountReadRecorder struct {
+	*state.StateDB
+	reads map[common.Address]int
+}
+
+func newCreateAccountReadRecorder(inner *state.StateDB) *createAccountReadRecorder {
+	return &createAccountReadRecorder{StateDB: inner, reads: make(map[common.Address]int)}
+}
+
+func (r *createAccountReadRecorder) GetCodeHash(addr common.Address) common.Hash {
+	r.reads[addr]++
+	return r.StateDB.GetCodeHash(addr)
+}
+
+func (r *createAccountReadRecorder) GetStorageRoot(addr common.Address) common.Hash {
+	r.reads[addr]++
+	return r.StateDB.GetStorageRoot(addr)
+}
+
+func (r *createAccountReadRecorder) GetNonce(addr common.Address) uint64 {
+	r.reads[addr]++
+	return r.StateDB.GetNonce(addr)
+}
+
+func (r *createAccountReadRecorder) Exist(addr common.Address) bool {
+	r.reads[addr]++
+	return r.StateDB.Exist(addr)
+}
+
+func (r *createAccountReadRecorder) GetBalance(addr common.Address) *uint256.Int {
+	r.reads[addr]++
+	return r.StateDB.GetBalance(addr)
+}
+
+func (r *createAccountReadRecorder) GetCode(addr common.Address) []byte {
+	r.reads[addr]++
+	return r.StateDB.GetCode(addr)
+}
+
+func TestUnzenZkGas_CreateSpawnLimitLeavesCreatedAccountUntouched(t *testing.T) {
+	initcode := common.Hex2Bytes("60005400")
+	for _, tt := range []struct {
+		name          string
+		opcode        OpCode
+		spawnEstimate uint64
+		outerCode     []byte
+		createdAddr   common.Address
+	}{
+		{
+			name:          "create",
+			opcode:        CREATE,
+			spawnEstimate: 37_000,
+			outerCode:     common.Hex2Bytes("63600054006000526004601c6000f000"),
+			createdAddr:   crypto.CreateAddress(spawnBoundaryOuterAddr, 0),
+		},
+		{
+			name:          "create2",
+			opcode:        CREATE2,
+			spawnEstimate: 44_500,
+			outerCode:     common.Hex2Bytes("636000540060005260006004601c6000f500"),
+			createdAddr:   crypto.CreateAddress2(spawnBoundaryOuterAddr, common.Hash{}, crypto.Keccak256(initcode)),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			schedule := &ZkGasSchedule{BlockLimit: tt.spawnEstimate - 1}
+			schedule.SpawnEstimates.Create = 37_000
+			schedule.SpawnEstimates.Create2 = 44_500
+			schedule.OpcodeMultipliers[byte(tt.opcode)] = 1
+
+			rules := params.MergedTestChainConfig.Rules(big.NewInt(1), true, 1)
+			inner, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+			inner.CreateAccount(spawnBoundaryOuterAddr)
+			inner.SetCode(spawnBoundaryOuterAddr, tt.outerCode, tracing.CodeChangeUnspecified)
+			inner.Finalise(true)
+			statedb := newCreateAccountReadRecorder(inner)
+
+			meter := NewZkGasMeter(schedule)
+			evm := NewEVM(BlockContext{
+				CanTransfer: func(StateDB, common.Address, *uint256.Int) bool { return true },
+				Transfer:    func(StateDB, common.Address, common.Address, *uint256.Int, *params.Rules) {},
+				BlockNumber: big.NewInt(1),
+				Time:        1,
+				Random:      &common.Hash{},
+			}, statedb, params.MergedTestChainConfig, Config{ZkGasMeter: meter})
+			statedb.Prepare(rules, common.Address{}, common.Address{}, &spawnBoundaryOuterAddr, ActivePrecompiles(rules), nil)
+
+			_, _, err := evm.Call(common.Address{}, spawnBoundaryOuterAddr, nil, 200_000, new(uint256.Int))
+			if err != ErrZkGasLimitExceeded {
+				t.Fatalf("Call err = %v, want ErrZkGasLimitExceeded", err)
+			}
+			if got := meter.TxZkGasUsed(); got != 0 {
+				t.Fatalf("TxZkGasUsed = %d, want 0", got)
+			}
+			if got := statedb.reads[tt.createdAddr]; got != 0 {
+				t.Fatalf("created account %s read %d times before the spawn charge failed, want 0", tt.createdAddr, got)
+			}
+		})
+	}
+}
+
+func newCreateShortfallEVM(t *testing.T, outerCode []byte, extraContracts map[common.Address][]byte) (*ZkGasMeter, *EVM) {
+	t.Helper()
+
+	schedule := &ZkGasSchedule{BlockLimit: 1 << 40}
+	schedule.SpawnEstimates.Create = 37_000
+	schedule.SpawnEstimates.Create2 = 44_500
+	schedule.OpcodeMultipliers[byte(CREATE)] = 1
+	schedule.OpcodeMultipliers[byte(CREATE2)] = 1
+
+	rules := params.MergedTestChainConfig.Rules(big.NewInt(1), true, 1)
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	statedb.CreateAccount(spawnBoundaryOuterAddr)
+	statedb.SetCode(spawnBoundaryOuterAddr, outerCode, tracing.CodeChangeUnspecified)
+	for addr, code := range extraContracts {
+		statedb.CreateAccount(addr)
+		statedb.SetCode(addr, code, tracing.CodeChangeUnspecified)
+	}
+	statedb.Finalise(true)
+
+	meter := NewZkGasMeter(schedule)
+	evm := NewEVM(BlockContext{
+		CanTransfer: func(StateDB, common.Address, *uint256.Int) bool { return true },
+		Transfer:    func(StateDB, common.Address, common.Address, *uint256.Int, *params.Rules) {},
+		BlockNumber: big.NewInt(1),
+		Time:        1,
+		Random:      &common.Hash{},
+	}, statedb, params.MergedTestChainConfig, Config{ZkGasMeter: meter})
+	statedb.Prepare(rules, common.Address{}, common.Address{}, &spawnBoundaryOuterAddr, ActivePrecompiles(rules), nil)
+	return meter, evm
+}
+
+func TestUnzenZkGas_CreateShortfallMirrorsReferenceChargeOrder(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		code    []byte
+		callGas uint64
+		wantErr error
+		want    uint64
+	}{
+		{
+			// Initcode word cost is affordable, memory expansion is not: the
+			// reference halts preserving gas, so only the initcode cost counts.
+			name:    "create memory unaffordable below base cost",
+			code:    common.Hex2Bytes("602063ffffffff6000f000"),
+			callGas: 20_000,
+			wantErr: ErrOutOfGas,
+			want:    2,
+		},
+		{
+			name:    "create2 memory unaffordable below base cost",
+			code:    common.Hex2Bytes("6000602063ffffffff6000f500"),
+			callGas: 20_000,
+			wantErr: ErrOutOfGas,
+			want:    2,
+		},
+		{
+			// Initcode word cost itself cannot be paid: the reference spends
+			// all remaining gas.
+			name:    "create initcode cost unaffordable spends all",
+			code:    common.Hex2Bytes("61c00060006000f000"),
+			callGas: 2_000,
+			wantErr: ErrOutOfGas,
+			want:    1_991,
+		},
+		{
+			// Oversized initcode halts before any charge in the reference.
+			name:    "create oversized initcode below base cost charges nothing",
+			code:    common.Hex2Bytes("61c00160006000f000"),
+			callGas: 20_000,
+			wantErr: ErrOutOfGas,
+			want:    0,
+		},
+		{
+			// Initcode and memory fit but the 32000 base cost does not: the
+			// reference spends all remaining gas.
+			name:    "create memory affordable base cost unaffordable spends all",
+			code:    common.Hex2Bytes("602060006000f000"),
+			callGas: 20_000,
+			wantErr: ErrOutOfGas,
+			want:    19_991,
+		},
+		{
+			// Offset operand beyond 64 bits halts after the initcode charge.
+			name:    "create offset overflow charges initcode cost",
+			code:    common.Hex2Bytes("60207fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff6000f000"),
+			callGas: 100_000,
+			wantErr: ErrGasUintOverflow,
+			want:    2,
+		},
+		{
+			// Size operand beyond 64 bits halts before any charge.
+			name:    "create size overflow charges nothing",
+			code:    common.Hex2Bytes("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff60006000f000"),
+			callGas: 100_000,
+			wantErr: ErrGasUintOverflow,
+			want:    0,
+		},
+		{
+			// Memory expansion cost overflows go-ethereum's cap: the reference
+			// still halts preserving gas after the initcode charge.
+			name:    "create memory cost overflow charges initcode cost",
+			code:    common.Hex2Bytes("6020650100000000006000f000"),
+			callGas: 100_000,
+			wantErr: ErrOutOfGas,
+			want:    2,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			meter, evm := newCreateShortfallEVM(t, tt.code, nil)
+
+			_, _, err := evm.Call(common.Address{}, spawnBoundaryOuterAddr, nil, tt.callGas, new(uint256.Int))
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Call err = %v, want %v", err, tt.wantErr)
+			}
+			if got := meter.TxZkGasUsed(); got != tt.want {
+				t.Fatalf("TxZkGasUsed = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnzenZkGas_CreateShortfallInStaticContextChargesNothing(t *testing.T) {
+	innerAddr := common.HexToAddress("0x2000000000000000000000000000000000000000")
+	innerCode := common.Hex2Bytes("602063ffffffff6000f000")
+	meter, evm := newCreateShortfallEVM(t, spawnBoundaryCallCode(STATICCALL, innerAddr), map[common.Address][]byte{
+		innerAddr: innerCode,
+	})
+
+	_, _, err := evm.Call(common.Address{}, spawnBoundaryOuterAddr, nil, 200_000, new(uint256.Int))
+	if err != nil {
+		t.Fatalf("Call returned error: %v", err)
+	}
+	if got := meter.TxZkGasUsed(); got != 0 {
+		t.Fatalf("TxZkGasUsed = %d, want 0 for a static-context CREATE shortfall", got)
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up to #586, closing the two remaining CREATE-family zk-gas boundary gaps against the alethia-reth/revm reference:

**1. Charge the CREATE/CREATE2 spawn estimate before touching the created account.**
#586 placed `chargePendingSpawn()` after geth's CREATE prelude (caller nonce bump, collision check, account setup, transfer). In revm, the CREATE instruction emits `NewFrame` without any created-account interaction — address derivation, nonce bump, collision check, and value transfer all live in frame init, and `run_metered_plain` charges the spawn estimate (and halts on limit-exceeded) before frame init can run. geth's collision check (`GetCodeHash`/`GetStorageRoot`/`GetNonce` on the created address) therefore added witness dependencies the reference never takes when the spawn charge is what crosses the block zk-gas limit — the same missing-trie-node-at-the-truncation-boundary signature #586 fixed for child execution. The charge now happens before any created-address access; the CALL-family placement is unchanged because revm's call instruction genuinely loads the target account and bytecode before `NewFrame`.

**2. Mirror revm's charge order for CREATE-family shortfalls that fail before the instruction body.**
geth fronts the 32000 CREATE base cost as `constantGas`, while revm charges CREATE-family in instruction order: static-context/operand/size validation halt before any charge (gas-preserving), the EIP-3860 initcode word cost spends all remaining gas when unaffordable, memory expansion halts preserving gas when unaffordable, and the trailing 32000 base (+ CREATE2 hashing) cost spends all remaining gas. Three geth paths measured this wrong:
- any CREATE/CREATE2 with less than 32000 remaining gas charged **all remaining gas** via the constant-gas shortfall path (reference: initcode cost only when memory expansion is the unaffordable step, zero for validation halts);
- memory-size operand overflows charged the fronted **32000** (reference: zero for a size-operand overflow, initcode cost for an offset overflow);
- memory-expansion costs beyond the uint64 cap charged **nothing** (reference: initcode cost).

Divergent per-step raw gas near the limit means divergent tx/block zk-gas totals, hence divergent Unzen `header.difficulty` (repurposed as finalized zk-gas and enforced on import by both clients) and a divergent truncation point — the two clients would reject each other's blocks. The new `zkGasCreateShortfallGasAfter` reconstructs the reference order for all three paths; non-CREATE opcodes are unaffected.

## Changes
- `core/vm/evm.go`: move `chargePendingSpawn()` in `create()` to before the caller nonce bump / access-list add / collision check; drop the old post-setup charge site.
- `core/vm/taiko_zk_gas_runtime.go`: add `zkGasCreateShortfallGasAfter` (reference charge-order reconstruction) and `zkGasMemorySizeOverflowGasAfter` (routes CREATE-family operand overflows through it, keeps `gasAfterStatic` for every other opcode).
- `core/vm/interpreter.go`: use the reconstruction in the constant-gas shortfall branch, both memory-size overflow branches, and meter CREATE-family `ErrGasUintOverflow` dynamic-gas failures that were previously skipped.
- Tests: created-account read-recorder proving a failed spawn charge leaves the created address untouched (previously 4 reads); a shortfall table covering every reference sub-case for CREATE and CREATE2 (memory-unaffordable, initcode-unaffordable, oversized initcode, base-cost-unaffordable, offset/size operand overflow, memory-cost overflow); a static-context shortfall case.

## Test Plan
- [x] go test ./core/vm/
- [x] go test ./core/...
- [x] go test ./miner/... ./consensus/taiko/... ./eth/tracers/...

🤖 Generated with [Claude Code](https://claude.com/claude-code)