### PR TITLE
chore(vm): preserve zk-gas for static-context CREATE dynamic shortfalls

### DIFF
--- a/core/vm/taiko_zk_gas_runtime.go
+++ b/core/vm/taiko_zk_gas_runtime.go
@@ -259,6 +259,11 @@ func (t *ZkGasStepTracker) markSpawn(depth int, matches func(byte) bool) {
 // CHANGE(taiko): zkGasDynamicOOGGasAfter mirrors REVM's callback-visible gas
 // for dynamic-cost shortfalls caught before go-ethereum executes the opcode.
 func zkGasDynamicOOGGasAfter(evm *EVM, op OpCode, stack *Stack, mem *Memory, memorySize, memoryLastGasCost, gasBefore, gasAfterStatic uint64) uint64 {
+	// REVM's CREATE-family static-context check halts before any charge, so a
+	// dynamic-gas shortfall go-ethereum catches first must preserve the gas.
+	if (op == CREATE || op == CREATE2) && evm.readOnly {
+		return gasBefore
+	}
 	preMemoryCost, gasBeforePreMemory, ok := zkGasPreMemoryCost(evm, op, stack, gasBefore, gasAfterStatic)
 	if !ok {
 		return 0

--- a/core/vm/taiko_zk_gas_runtime_test.go
+++ b/core/vm/taiko_zk_gas_runtime_test.go
@@ -924,6 +924,12 @@ func executeUnzenZkGasParityCase(t *testing.T, code []byte, extraContracts map[c
 var spawnBoundaryOuterAddr = common.HexToAddress("0x1000000000000000000000000000000000000000")
 
 func spawnBoundaryCallCode(opcode OpCode, target common.Address) []byte {
+	return spawnBoundaryCallCodeWithGas(opcode, target, 0x2710)
+}
+
+// spawnBoundaryCallCodeWithGas forwards the given gas to the child frame so
+// tests can steer which shortfall guard a child opcode fails in.
+func spawnBoundaryCallCodeWithGas(opcode OpCode, target common.Address, gas uint16) []byte {
 	code := []byte{
 		byte(PUSH1), 0x00, // retSize
 		byte(PUSH1), 0x00, // retOffset
@@ -935,7 +941,7 @@ func spawnBoundaryCallCode(opcode OpCode, target common.Address) []byte {
 	}
 	code = append(code, byte(PUSH20))
 	code = append(code, target.Bytes()...)
-	code = append(code, byte(PUSH2), 0x27, 0x10, byte(opcode), byte(STOP))
+	code = append(code, byte(PUSH2), byte(gas>>8), byte(gas), byte(opcode), byte(STOP))
 	return code
 }
 
@@ -1417,6 +1423,35 @@ func TestUnzenZkGas_CreateShortfallInStaticContextChargesNothing(t *testing.T) {
 	}
 	if got := meter.TxZkGasUsed(); got != 0 {
 		t.Fatalf("TxZkGasUsed = %d, want 0 for a static-context CREATE shortfall", got)
+	}
+}
+
+func TestUnzenZkGas_CreateDynamicOOGInStaticContextChargesNothing(t *testing.T) {
+	innerAddr := common.HexToAddress("0x2000000000000000000000000000000000000000")
+	for _, tt := range []struct {
+		name      string
+		innerCode []byte
+	}{
+		// The fronted 32000 constant is affordable but the memory expansion
+		// is not, so the shortfall surfaces in the dynamic-gas guard instead
+		// of the constant-gas one. The reference halts on its static-context
+		// check before charging anything.
+		{"create", common.Hex2Bytes("602063ffffffff6000f000")},
+		{"create2", common.Hex2Bytes("6000602063ffffffff6000f500")},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			meter, evm := newCreateShortfallEVM(t, spawnBoundaryCallCodeWithGas(STATICCALL, innerAddr, 0xffff), map[common.Address][]byte{
+				innerAddr: tt.innerCode,
+			})
+
+			_, _, err := evm.Call(common.Address{}, spawnBoundaryOuterAddr, nil, 200_000, new(uint256.Int))
+			if err != nil {
+				t.Fatalf("Call returned error: %v", err)
+			}
+			if got := meter.TxZkGasUsed(); got != 0 {
+				t.Fatalf("TxZkGasUsed = %d, want 0 for a static-context dynamic-gas shortfall", got)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #587, closing the last CREATE-family zk-gas boundary gap against the alethia-reth/revm reference.

A CREATE/CREATE2 executed inside a read-only (STATICCALL) frame with ≥ 32000 remaining gas and an unaffordable — but uint64-representable — memory expansion fails geth's dynamic-gas guard (`contract.Gas < dynamicCost`), which routed through `zkGasDynamicOOGGasAfter` and metered the EIP-3860 initcode word cost (2 up to ~3072 raw zk-gas; e.g. `offset=0xffffffff, size=32` → 2). revm's `create`/`create2` instructions run `require_non_staticcall!` before popping operands or charging anything, so the reference meter records 0 for the same step.

Divergent per-step zk-gas means divergent tx/block zk-gas totals → divergent Unzen `header.difficulty` (repurposed as finalized zk-gas, enforced on import by both clients) and a divergent truncation point → the clients reject each other's blocks. Adversarially trivial to reach: any contract can STATICCALL into code that attempts a doomed CREATE.

#587 added the read-only guard to the constant-gas shortfall reconstruction (`zkGasCreateBodyGasAfter`) but not to the dynamic-gas shortfall path, and its static-context test forwarded only 10,000 gas — below the 32000 constant — so it exercised only the guarded band.

## Changes
- `core/vm/taiko_zk_gas_runtime.go`: return `gasBefore` (charge nothing) from `zkGasDynamicOOGGasAfter` for read-only CREATE/CREATE2, mirroring the reference's check-before-charge order. Covers both dynamic-gas failure call sites (`dynamicGas` error and unaffordable `dynamicCost`); non-CREATE opcodes unchanged.
- `core/vm/taiko_zk_gas_runtime_test.go`: parameterize the spawn-boundary outer-code helper by forwarded gas; add a static-context test forwarding 0xffff gas so the shortfall lands in the dynamic-gas guard, for both CREATE and CREATE2 (previously metered 2, now 0).

## Test Plan
- [x] go test ./core/vm/
- [x] go test ./core/... ./miner/... ./consensus/taiko/... ./eth/tracers/...

🤖 Generated with [Claude Code](https://claude.com/claude-code)