### PR TITLE
chore(vm): meter dynamic write-protection zk-gas

### DIFF
--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -299,6 +299,17 @@ func (evm *EVM) Run(contract *Contract, input []byte, readOnly bool) (ret []byte
 						return nil, ErrZkGasLimitExceeded
 					}
 				}
+				// CHANGE(taiko): dynamic-gas write-protection failures occur
+				// before go-ethereum reaches opcode execution. REVM has already
+				// deducted the instruction-table static gas at that point, so
+				// mirror the same pre-execution charge here.
+				if evm.zkGasTracker != nil && evm.zkGasErr == nil && errors.Is(err, ErrWriteProtection) {
+					evm.zkGasTracker.Begin(evm.depth, byte(op), gasBefore)
+					if zkErr := evm.zkGasTracker.FinishAndCharge(evm.depth, zkGasPreExecutionGasAfter(op, gasBefore)); zkErr != nil {
+						evm.setZkGasErr()
+						return nil, ErrZkGasLimitExceeded
+					}
+				}
 				// CHANGE(taiko): a CREATE-family memory cost beyond the uint64
 				// cap halts REVM while preserving the gas left after its
 				// initcode charge, so it must be metered instead of skipped.

--- a/core/vm/taiko_zk_gas_runtime_test.go
+++ b/core/vm/taiko_zk_gas_runtime_test.go
@@ -1455,6 +1455,50 @@ func TestUnzenZkGas_CreateDynamicOOGInStaticContextChargesNothing(t *testing.T) 
 	}
 }
 
+func TestUnzenZkGas_DynamicWriteProtectionChargesRevmStaticGas(t *testing.T) {
+	innerAddr := common.HexToAddress("0x2000000000000000000000000000000000000000")
+	targetAddr := common.HexToAddress("0x3000000000000000000000000000000000000000")
+
+	callWithValue := []byte{
+		byte(PUSH1), 0x00, // retSize
+		byte(PUSH1), 0x00, // retOffset
+		byte(PUSH1), 0x00, // inSize
+		byte(PUSH1), 0x00, // inOffset
+		byte(PUSH1), 0x01, // value
+		byte(PUSH20),
+	}
+	callWithValue = append(callWithValue, targetAddr.Bytes()...)
+	callWithValue = append(callWithValue, byte(PUSH2), 0xff, 0xff, byte(CALL), byte(STOP))
+
+	selfDestruct := []byte{byte(PUSH20)}
+	selfDestruct = append(selfDestruct, targetAddr.Bytes()...)
+	selfDestruct = append(selfDestruct, byte(SELFDESTRUCT), byte(STOP))
+
+	for _, tt := range []struct {
+		name      string
+		opcode    OpCode
+		innerCode []byte
+		want      uint64
+	}{
+		{"call value transfer", CALL, callWithValue, zkGasRevmStaticGas[CALL]},
+		{"selfdestruct", SELFDESTRUCT, selfDestruct, zkGasRevmStaticGas[SELFDESTRUCT]},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			meter, evm := newSpawnBoundaryEVM(t, spawnBoundaryCallCodeWithGas(STATICCALL, innerAddr, 0xffff), map[common.Address][]byte{
+				innerAddr: tt.innerCode,
+			}, tt.opcode, 200_000)
+
+			_, _, err := evm.Call(common.Address{}, spawnBoundaryOuterAddr, nil, 200_000, new(uint256.Int))
+			if err != nil {
+				t.Fatalf("Call returned error: %v", err)
+			}
+			if got := meter.TxZkGasUsed(); got != tt.want {
+				t.Fatalf("TxZkGasUsed = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestUnzenZkGas_Create2SaltUnderflowMirrorsReferenceChargeOrder(t *testing.T) {
 	for _, tt := range []struct {
 		name    string


### PR DESCRIPTION
## Summary

Follow-up to #588 for the remaining dynamic-gas write-protection path.

`CALL` with non-zero value inside a `STATICCALL` frame and `SELFDESTRUCT` inside a static frame can return `ErrWriteProtection` from the dynamic-gas phase before go-ethereum reaches opcode execution. Before this change, that error path skipped the pending zk-gas step and charged `0`.

REVM has already deducted the instruction-table static gas at that point, so taiko-geth must mirror the pre-execution charge:

- `CALL(value)` in static context: `100`
- `SELFDESTRUCT` in static context: `5000`

`SSTORE` still charges `0` because its REVM static gas entry is `0`.

## Changes

- Finish pending zk-gas steps when `dynamicGas` returns `ErrWriteProtection`.
- Add regression coverage for `STATICCALL -> CALL(value)` and `STATICCALL -> SELFDESTRUCT`.

## Test Plan

- [x] `go test ./core/vm -run TestUnzenZkGas_DynamicWriteProtectionChargesRevmStaticGas -count=1 -v`
- [x] `go test ./core/vm -run 'TestUnzenZkGas_(DynamicWriteProtectionChargesRevmStaticGas|CreateDynamicOOGInStaticContextChargesNothing|CreateShortfallInStaticContextChargesNothing|PreExecutionFailuresMirrorRevmStaticGas|Create2SaltUnderflowMirrorsReferenceChargeOrder)' -count=1 -v`
- [x] `go test ./core/vm -count=1`
- [x] `go test ./core/... ./miner/... ./consensus/taiko/... ./eth/tracers/...`
