### PR TITLE
feat(eth): align tx-list witness acceptance with the reference replay

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -725,8 +725,14 @@ func (st *stateTransition) blobGasUsed() uint64 {
 
 // CHANGE(taiko): returns the treasury address based on chain ID.
 func (st *stateTransition) getTreasuryAddress() common.Address {
+	return TaikoTreasuryAddress(st.evm.ChainConfig().ChainID)
+}
+
+// CHANGE(taiko): TaikoTreasuryAddress derives the network treasury address
+// from the chain ID: the decimal chain id, zero padding, and a 10001 suffix.
+func TaikoTreasuryAddress(chainID *big.Int) common.Address {
 	var (
-		prefix = st.evm.ChainConfig().ChainID.String()
+		prefix = chainID.String()
 		suffix = "10001"
 	)
 	return common.HexToAddress(

--- a/eth/taiko_api_debug.go
+++ b/eth/taiko_api_debug.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/consensus/taiko"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/stateless"
@@ -41,15 +42,28 @@ type txListWitnessOptions struct {
 	SkipZkGasDifficultyCheck bool `json:"skipZkGasDifficultyCheck"`
 }
 
-// decodeTxListWitnessTxs decodes an RLP list of transactions. It errors only on
-// a malformed top-level list; unrecoverable-signer transactions are filtered
-// later during replay, matching block-building behavior.
+// decodeTxListWitnessTxs decodes an RLP list of transactions and drops any
+// whose signature cannot be recovered, mirroring the reference ingestion: list
+// positions are assigned after the drop, so the first remaining transaction —
+// not the first decoded one — takes the first-position fatality role below.
+// It errors only on a malformed top-level list.
 func decodeTxListWitnessTxs(txListRLP []byte) (types.Transactions, error) {
 	var txs types.Transactions
 	if err := rlp.DecodeBytes(txListRLP, &txs); err != nil {
 		return nil, fmt.Errorf("failed to decode tx list: %w", err)
 	}
-	return txs, nil
+	recovered := make(types.Transactions, 0, len(txs))
+	for _, tx := range txs {
+		// Recover with the transaction's own chain id: chain-id and fork-type
+		// mismatches are execution-time skips (like the reference EVM's
+		// validation), while a cryptographically unrecoverable signature drops
+		// the transaction before positions are assigned.
+		if _, err := types.Sender(types.LatestSignerForChainID(tx.ChainId()), tx); err != nil {
+			continue
+		}
+		recovered = append(recovered, tx)
+	}
+	return recovered, nil
 }
 
 // checkTxListSize rejects a transaction list too large to be a valid block list.
@@ -118,6 +132,10 @@ var recoverableNonAnchorTxErrors = []error{
 	core.ErrEmptyAuthList,
 	core.ErrSetCodeTxCreate,
 	core.ErrGasLimitTooHigh,
+	// CHANGE(taiko): the reference EVM reports an over-limit initcode as an
+	// invalid-transaction validation error, which its replay skips like the
+	// rest of this set.
+	vm.ErrMaxInitCodeSizeExceeded,
 }
 
 func isRecoverableNonAnchorTxError(err error) bool {
@@ -131,9 +149,12 @@ func isRecoverableNonAnchorTxError(err error) bool {
 
 // CHANGE(taiko): buildTxListWitness replays txs on top of the parent state of
 // `block` and returns the collected execution witness plus the committed
-// (post-filter) transactions. It mirrors the block-builder's filtering: the
-// anchor (index 0) must succeed; non-anchor failures are skipped; a non-anchor
-// zk-gas-limit error truncates the block.
+// (post-filter) transactions. It mirrors the reference replay: the first
+// transaction must succeed (any failure there is fatal), later failures in the
+// recoverable class are skipped, and a zk-gas-limit error truncates the block.
+// Anchor execution exemptions follow the reference identity — the golden-touch
+// sender, its block-start nonce, and the treasury target — at any position,
+// independent of transaction type.
 func buildTxListWitness(bc *core.BlockChain, block *types.Block, txs types.Transactions, opts txListWitnessOptions) (*stateless.Witness, types.Transactions, error) {
 	config := bc.Config()
 	header := block.Header() // copy; safe to mutate during finalize
@@ -193,25 +214,39 @@ func buildTxListWitness(bc *core.BlockChain, block *types.Block, txs types.Trans
 	gasPool := core.NewGasPool(header.GasLimit)
 	rules := config.Rules(header.Number, true, header.Time)
 	signer := types.LatestSignerForChainID(config.ChainID)
+	msgSigner := types.MakeSigner(config, header.Number, header.Time)
+
+	// CHANGE(taiko): the reference block executor identifies the anchor by the
+	// (sender, nonce, target) triple — the golden touch, its account nonce
+	// before any replayed transaction, and the chain's treasury — never by list
+	// position or transaction type. Its pre-execution marker call also loads
+	// the golden-touch and treasury accounts, so the equivalent reads here keep
+	// the witness carrying the same pre-execution dependencies.
+	var (
+		goldenTouchNonce uint64
+		treasury         common.Address
+	)
+	if config.Taiko {
+		goldenTouchNonce = statedb.GetNonce(taiko.GoldenTouchAccount)
+		treasury = core.TaikoTreasuryAddress(config.ChainID)
+		statedb.GetBalance(treasury)
+	}
 
 	committed := make(types.Transactions, 0, len(txs))
 	for i, tx := range txs {
-		isAnchor := i == 0 && config.Taiko
-		if isAnchor {
-			if err := tx.MarkAsAnchor(); err != nil {
-				return nil, nil, fmt.Errorf("anchor transaction invalid: %w", err)
-			}
-		}
+		// The first list position only decides fatality: any failure there
+		// aborts the request instead of skipping the transaction.
+		isFirst := i == 0 && config.Taiko
 		if tx.Type() == types.BlobTxType {
-			if isAnchor {
-				return nil, nil, errors.New("anchor transaction must not be a blob transaction")
+			if isFirst {
+				return nil, nil, errors.New("first transaction must not be a blob transaction")
 			}
 			continue
 		}
 		sender, err := signer.Sender(tx)
 		if err != nil {
-			if isAnchor {
-				return nil, nil, fmt.Errorf("anchor transaction sender unrecoverable: %w", err)
+			if isFirst {
+				return nil, nil, fmt.Errorf("first transaction sender invalid: %w", err)
 			}
 			continue
 		}
@@ -223,20 +258,44 @@ func buildTxListWitness(bc *core.BlockChain, block *types.Block, txs types.Trans
 			evm.ResetZkGasErr()
 		}
 
+		msg, err := core.TransactionToMessage(tx, msgSigner, header.BaseFee)
+		if err != nil {
+			// Fork-gated transaction types surface here; the reference EVM
+			// rejects them at validation, which its replay treats like any
+			// other recoverable failure.
+			if isFirst {
+				return nil, nil, fmt.Errorf("transaction at index 0 failed: %w", err)
+			}
+			if !isRecoverableNonAnchorTxError(err) {
+				return nil, nil, fmt.Errorf("non-anchor transaction at index %d failed: %w", i, err)
+			}
+			continue
+		}
+		if config.IsShasta(header.Time) {
+			msg.BasefeeSharingPctg = core.DecodeShastaBasefeeSharingPctg(header.Extra)
+		} else if config.IsOntake(header.Number) {
+			msg.BasefeeSharingPctg = core.DecodeOntakeExtraData(header.Extra)
+		}
+		// CHANGE(taiko): anchor exemptions follow the reference triple at any
+		// list position; the assignment also clears any in-memory flag the
+		// transaction object may carry.
+		msg.IsAnchor = config.Taiko && sender == taiko.GoldenTouchAccount &&
+			tx.Nonce() == goldenTouchNonce && tx.To() != nil && *tx.To() == treasury
+
 		snap := statedb.Snapshot()
 		gpSnap := gasPool.Snapshot()
-		if _, err := core.ApplyTransaction(evm, gasPool, statedb, header, tx); err != nil {
+		if _, err := core.ApplyTransactionWithEVM(msg, gasPool, statedb, header.Number, header.Hash(), header.Time, tx, evm); err != nil {
 			statedb.RevertToSnapshot(snap)
 			gasPool.Set(gpSnap)
-			if isAnchor {
-				return nil, nil, fmt.Errorf("anchor transaction failed: %w", err)
+			if isFirst {
+				return nil, nil, fmt.Errorf("transaction at index 0 failed: %w", err)
 			}
 			// CHANGE(taiko): tolerate only the recoverable error set the block
 			// builder skips for non-anchor txs; any other error is fatal.
 			if !isRecoverableNonAnchorTxError(err) {
 				return nil, nil, fmt.Errorf("non-anchor transaction at index %d failed: %w", i, err)
 			}
-			// A non-anchor zk-gas-limit error truncates the block.
+			// A non-first zk-gas-limit error truncates the block.
 			if zkGasMeter != nil && errors.Is(err, vm.ErrZkGasLimitExceeded) {
 				zkGasMeter.ResetTransaction()
 				evm.ResetZkGasErr()

--- a/eth/taiko_api_debug_integration_test.go
+++ b/eth/taiko_api_debug_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/beacon"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/consensus/taiko"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/stateless"
@@ -813,5 +814,174 @@ func TestBuildTxListWitnessRevealsCollapseSiblingOnDelete(t *testing.T) {
 		common.HexToHash("0x03"), common.Hash{})
 	if _, ok := witness.State[string(proof497[2])]; !ok {
 		t.Fatalf("surviving sibling leaf missing from witness state after branch-collapsing delete")
+	}
+}
+
+// goldenTouchTestKey is the well-known golden-touch signing key (also used by
+// the consensus package tests).
+func goldenTouchTestKey(t *testing.T) *ecdsa.PrivateKey {
+	t.Helper()
+	key, err := crypto.HexToECDSA("92954368afd3caa1f3ce3ead0069c1af414054aefe1ef9aeacc1bf426222ce38")
+	if err != nil {
+		t.Fatalf("golden touch key: %v", err)
+	}
+	if got := crypto.PubkeyToAddress(key.PublicKey); got != taiko.GoldenTouchAccount {
+		t.Fatalf("golden touch key derives %s, want %s", got, taiko.GoldenTouchAccount)
+	}
+	return key
+}
+
+// goldenTouchTripleTx signs a transaction from the golden touch to the chain's
+// treasury with the golden touch's block-start nonce — the reference anchor
+// identity.
+func goldenTouchTripleTx(t *testing.T, bc *core.BlockChain, baseFee *big.Int) *types.Transaction {
+	t.Helper()
+	treasury := core.TaikoTreasuryAddress(bc.Config().ChainID)
+	tx, err := types.SignTx(types.NewTx(&types.DynamicFeeTx{
+		ChainID: bc.Config().ChainID, Nonce: 0, GasTipCap: big.NewInt(0),
+		GasFeeCap: baseFee, Gas: 1_000_000, To: &treasury, Value: common.Big0,
+	}), types.LatestSigner(bc.Config()), goldenTouchTestKey(t))
+	if err != nil {
+		t.Fatalf("sign golden touch tx: %v", err)
+	}
+	return tx
+}
+
+// TestBuildTxListWitnessGoldenTouchTripleGetsAnchorExemptions: the reference
+// grants anchor execution exemptions to the (golden touch, block-start nonce,
+// treasury) triple at any list position — the unfunded golden touch must
+// execute without buying gas even when it is not the first transaction.
+func TestBuildTxListWitnessGoldenTouchTripleGetsAnchorExemptions(t *testing.T) {
+	bc, blocks, _ := newTxListWitnessChain(t, witnessChainConfig{blocks: 1, transferTxs: 1})
+	block := blocks[0]
+
+	t.Run("first position", func(t *testing.T) {
+		// A fresh tx per subtest: the transaction object must carry no
+		// in-memory anchor flag from a previous replay.
+		gtTx := goldenTouchTripleTx(t, bc, block.BaseFee())
+		_, committed, err := buildTxListWitness(bc, block, types.Transactions{gtTx}, txListWitnessOptions{})
+		if err != nil {
+			t.Fatalf("buildTxListWitness: %v", err)
+		}
+		if len(committed) != 1 {
+			t.Fatalf("expected the golden touch tx committed, got %d", len(committed))
+		}
+	})
+
+	t.Run("later position", func(t *testing.T) {
+		gtTx := goldenTouchTripleTx(t, bc, block.BaseFee())
+		first := block.Transactions()[0] // funded sender, executes as a normal tx
+		_, committed, err := buildTxListWitness(bc, block, types.Transactions{first, gtTx}, txListWitnessOptions{})
+		if err != nil {
+			t.Fatalf("buildTxListWitness: %v", err)
+		}
+		if len(committed) != 2 {
+			t.Fatalf("expected both txs committed, got %d", len(committed))
+		}
+		if committed[1].Hash() != gtTx.Hash() {
+			t.Fatalf("expected the golden touch tx committed at position 1")
+		}
+	})
+}
+
+// TestBuildTxListWitnessFirstTxWithoutTripleGetsNoExemptions: a first-position
+// transaction from an ordinary zero-balance sender is a normal fee-paying
+// transaction in the reference, so it must fail the replay fatally instead of
+// silently executing with anchor exemptions.
+func TestBuildTxListWitnessFirstTxWithoutTripleGetsNoExemptions(t *testing.T) {
+	bc, blocks, _ := newTxListWitnessChain(t, witnessChainConfig{blocks: 1})
+	block := blocks[0]
+
+	key, _ := crypto.GenerateKey() // zero balance
+	dst := common.HexToAddress("0x00000000000000000000000000000000deadbeef")
+	tx, _ := types.SignTx(types.NewTx(&types.DynamicFeeTx{
+		ChainID: bc.Config().ChainID, Nonce: 0, GasTipCap: big.NewInt(0),
+		GasFeeCap: block.BaseFee(), Gas: 100000, To: &dst, Value: common.Big0,
+	}), types.LatestSigner(bc.Config()), key)
+
+	if _, _, err := buildTxListWitness(bc, block, types.Transactions{tx}, txListWitnessOptions{}); err == nil {
+		t.Fatalf("expected fatal error: zero-balance first tx must pay for gas")
+	}
+}
+
+// TestBuildTxListWitnessLegacyFirstTxExecutes: the reference has no
+// transaction-type requirement on the first list position; a funded legacy
+// transaction must replay as a normal transaction instead of failing the
+// request.
+func TestBuildTxListWitnessLegacyFirstTxExecutes(t *testing.T) {
+	bc, blocks, key := newTxListWitnessChain(t, witnessChainConfig{blocks: 1, transferTxs: 1})
+	block := blocks[0]
+
+	dst := common.HexToAddress("0x00000000000000000000000000000000deadbeef")
+	// The replay runs on the parent (genesis) state, where the funded key's
+	// next nonce is 0.
+	legacy, err := types.SignTx(types.NewTx(&types.LegacyTx{
+		Nonce: 0, To: &dst, Value: common.Big0, Gas: 100000, GasPrice: block.BaseFee(),
+	}), types.LatestSigner(bc.Config()), key)
+	if err != nil {
+		t.Fatalf("sign legacy tx: %v", err)
+	}
+
+	_, committed, err := buildTxListWitness(bc, block, types.Transactions{legacy}, txListWitnessOptions{})
+	if err != nil {
+		t.Fatalf("buildTxListWitness: %v", err)
+	}
+	if len(committed) != 1 {
+		t.Fatalf("expected the legacy tx committed, got %d", len(committed))
+	}
+}
+
+// TestBuildTxListWitnessSkipsOversizedInitcodeTx: an over-limit initcode
+// creation is a recoverable skip in the reference replay, not a fatal error.
+func TestBuildTxListWitnessSkipsOversizedInitcodeTx(t *testing.T) {
+	bc, blocks, key := newTxListWitnessChain(t, witnessChainConfig{blocks: 1, transferTxs: 1})
+	block := blocks[0]
+
+	signer := types.LatestSigner(bc.Config())
+	oversized, err := types.SignTx(types.NewTx(&types.DynamicFeeTx{
+		ChainID: bc.Config().ChainID, Nonce: 2, GasTipCap: big.NewInt(0),
+		GasFeeCap: block.BaseFee(), Gas: 2_000_000, To: nil, Value: common.Big0,
+		Data: make([]byte, params.MaxInitCodeSize+1),
+	}), signer, key)
+	if err != nil {
+		t.Fatalf("sign oversized initcode tx: %v", err)
+	}
+
+	first := block.Transactions()[0]
+	second := block.Transactions()[1]
+	_, committed, err := buildTxListWitness(bc, block, types.Transactions{first, second, oversized}, txListWitnessOptions{})
+	if err != nil {
+		t.Fatalf("buildTxListWitness: %v", err)
+	}
+	if len(committed) != 2 {
+		t.Fatalf("expected oversized-initcode tx skipped, got %d committed", len(committed))
+	}
+}
+
+// TestExecutionWitnessForTxListDropsUnrecoverableSigner: a transaction whose
+// signature cannot be recovered is dropped at decode time, before list
+// positions are assigned — the request must succeed with the remaining
+// transactions taking their shifted positions.
+func TestExecutionWitnessForTxListDropsUnrecoverableSigner(t *testing.T) {
+	bc, blocks, _ := newTxListWitnessChain(t, witnessChainConfig{blocks: 1, transferTxs: 1})
+	block := blocks[0]
+
+	junk, err := block.Transactions()[0].WithSignature(types.LatestSigner(bc.Config()), make([]byte, 65))
+	if err != nil {
+		t.Fatalf("make junk-signature tx: %v", err)
+	}
+	txs := append(types.Transactions{junk}, block.Transactions()...)
+	rlpTxs, err := rlp.EncodeToBytes(txs)
+	if err != nil {
+		t.Fatalf("encode txs: %v", err)
+	}
+
+	bn := rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(block.NumberU64()))
+	out, err := executionWitnessForTxList(bc, bn, rlpTxs, nil, nil)
+	if err != nil {
+		t.Fatalf("executionWitnessForTxList: %v", err)
+	}
+	if len(out.State) == 0 {
+		t.Fatalf("expected a witness for the recoverable remainder of the list")
 	}
 }

--- a/eth/taiko_api_debug_test.go
+++ b/eth/taiko_api_debug_test.go
@@ -7,8 +7,12 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rlp"
 )
 
 func TestDecodeTxListWitnessTxsEmpty(t *testing.T) {
@@ -81,5 +85,41 @@ func TestIsRecoverableNonAnchorTxError(t *testing.T) {
 	}
 	if isRecoverableNonAnchorTxError(fmt.Errorf("wrapped: %w", errors.New("boom"))) {
 		t.Fatalf("wrapped unrelated error must not be recoverable")
+	}
+}
+
+func TestIsRecoverableNonAnchorTxErrorIncludesInitcodeLimit(t *testing.T) {
+	// The reference replay skips over-limit initcode creations like any other
+	// invalid-transaction precheck failure.
+	if !isRecoverableNonAnchorTxError(fmt.Errorf("apply tx: %w", vm.ErrMaxInitCodeSizeExceeded)) {
+		t.Fatalf("expected max-initcode-size errors to be recoverable")
+	}
+}
+
+func TestDecodeTxListWitnessTxsDropsUnrecoverableSigners(t *testing.T) {
+	key, _ := crypto.GenerateKey()
+	signer := types.LatestSignerForChainID(big.NewInt(167000))
+	valid, err := types.SignTx(types.NewTx(&types.DynamicFeeTx{
+		ChainID: big.NewInt(167000), Nonce: 0, GasTipCap: big.NewInt(0),
+		GasFeeCap: big.NewInt(1), Gas: 21000, To: &common.Address{}, Value: big.NewInt(0),
+	}), signer, key)
+	if err != nil {
+		t.Fatalf("sign tx: %v", err)
+	}
+	junk, err := valid.WithSignature(signer, make([]byte, 65))
+	if err != nil {
+		t.Fatalf("junk signature: %v", err)
+	}
+
+	encoded, err := rlp.EncodeToBytes(types.Transactions{junk, valid})
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	txs, err := decodeTxListWitnessTxs(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(txs) != 1 || txs[0].Hash() != valid.Hash() {
+		t.Fatalf("expected only the recoverable tx to survive decode, got %d", len(txs))
 	}
 }


### PR DESCRIPTION
## Summary

Closes the three remaining acceptance divergences between `debug_executionWitnessForTxList` and the alethia-reth reference replay (audit items: anchor identification, unrecoverable-signer handling, initcode-size recoverability). These are the gaps that let a hostile tx list split the proving lanes: raiko2 fetches witnesses exclusively from the reth endpoint, while the gaiko2 SGX lane re-derives the same list with this (vendored) geth code — any acceptance difference makes the SGX lane fail to prove, or prove a different post-state than, exactly the proposals an adversary crafts.

**Reference semantics matched** (alethia-reth `crates/rpc/src/debug.rs`, `crates/primitives/src/payload/builder.rs:243`, `crates/evm/src/handler.rs:219`):

1. **Anchor identity is the (golden touch, block-start nonce, treasury) triple, at any list position — never position or transaction type.** Previously index 0 had to be a `DynamicFeeTx` (legacy/2930/7702 first tx → fatal, reth executes them), was force-marked as anchor (a zero-balance non-golden-touch 1559 first tx silently executed with anchor exemptions here while reth fails it with `LackOfFundForMaxFee` — divergent acceptance *and* state), and a triple-matching golden-touch tx at index ≥ 1 got normal fee handling here but anchor exemptions in reth (divergent state root). The replay now reads the golden-touch nonce from block-start state, keys `msg.IsAnchor` on the triple (message-level; in-memory tx flags are cleared), and witnesses the golden-touch/treasury accounts like the reference pre-execution marker call.
2. **Signature-unrecoverable transactions drop at decode time, before positions are assigned** (`decode_recovered_transactions` parity): a garbage-signature tx at index 0 no longer aborts the request — the first *recoverable* transaction takes the first-position role. Recovery uses each transaction's own chain id, so wrong-chain-id and fork-gated-type txs remain execution-time skips (fatal at index 0), matching reth's `validate_env` outcomes.
3. **First position decides fatality only** (`is_recoverable_tx_list_error = !is_anchor && recoverable`): any first-tx failure is fatal, later failures skip if recoverable; blob rules unchanged (fatal first, skipped later). `vm.ErrMaxInitCodeSizeExceeded` joins the recoverable set — reth maps `CreateInitCodeSizeLimit` to a recoverable `InvalidTx` skip, while geth treated it as fatal.

Also exposes `core.TaikoTreasuryAddress` (same derivation the state transition uses) for the triple check.

Canonical driver-built lists are unaffected: the driver always prepends a type-2 golden-touch anchor with the correct nonce and treasury target, which matches the triple at index 0 exactly as before.

## Test Plan

- [x] Red/green TDD: 7 new cases failed on the old behavior, pass now — golden-touch triple exemptions at index 0 and index ≥ 1, zero-balance first tx without the triple is fatal (exemption removal), funded legacy first tx executes, oversized-initcode tx skips, junk-signature tx drops at decode (unit + end-to-end), initcode error recoverable (unit)
- [x] All pre-existing witness tests pass unchanged (state-root reproduction, skip/fatal semantics, system-call and extension-split coverage)
- [x] go test ./eth/ ./core/... ./miner/... ./consensus/taiko/...
- [x] gofmt / go vet clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)