### PR TITLE
chore(vm): align LOG zk-gas shortfall and static-context boundaries

### DIFF
--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -212,6 +212,13 @@ func (evm *EVM) Run(contract *Contract, input []byte, readOnly bool) (ret []byte
 				if op == CREATE2 && sLen == 3 {
 					gasAfterUnderflow = zkGasCreate2SaltUnderflowGasAfter(evm, stack, mem, gasBefore)
 				}
+				// CHANGE(taiko): LOG pops its topics only after REVM charges
+				// the topic+data cost and memory expansion, so a stack holding
+				// the two memory operands but missing topics must meter those
+				// in-body charges the same way.
+				if op >= LOG1 && op <= LOG4 && sLen >= 2 {
+					gasAfterUnderflow = zkGasLogShortfallGasAfter(evm, op, stack, mem, gasBefore)
+				}
 				if zkErr := evm.zkGasTracker.FinishAndCharge(evm.depth, gasAfterUnderflow); zkErr != nil {
 					evm.setZkGasErr()
 					return nil, ErrZkGasLimitExceeded

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -312,10 +312,12 @@ func (evm *EVM) Run(contract *Contract, input []byte, readOnly bool) (ret []byte
 				}
 				// CHANGE(taiko): a CREATE-family memory cost beyond the uint64
 				// cap halts REVM while preserving the gas left after its
-				// initcode charge, so it must be metered instead of skipped.
-				if evm.zkGasTracker != nil && evm.zkGasErr == nil && (op == CREATE || op == CREATE2) && errors.Is(err, ErrGasUintOverflow) {
+				// initcode charge, and a LOG operand or memory cost beyond the
+				// cap halts REVM around its in-body topic+data charge, so both
+				// must be metered instead of skipped.
+				if evm.zkGasTracker != nil && evm.zkGasErr == nil && errors.Is(err, ErrGasUintOverflow) && zkGasStaticContextHaltsBeforeBody(op) {
 					evm.zkGasTracker.Begin(evm.depth, byte(op), gasBefore)
-					if zkErr := evm.zkGasTracker.FinishAndCharge(evm.depth, zkGasCreateShortfallGasAfter(evm, stack, mem, gasBefore)); zkErr != nil {
+					if zkErr := evm.zkGasTracker.FinishAndCharge(evm.depth, zkGasMemorySizeOverflowGasAfter(evm, op, stack, mem, gasBefore, gasAfterStatic)); zkErr != nil {
 						evm.setZkGasErr()
 						return nil, ErrZkGasLimitExceeded
 					}

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -310,16 +310,17 @@ func (evm *EVM) Run(contract *Contract, input []byte, readOnly bool) (ret []byte
 						return nil, ErrZkGasLimitExceeded
 					}
 				}
-				// CHANGE(taiko): a CREATE-family memory cost beyond the uint64
-				// cap halts REVM while preserving the gas left after its
-				// initcode charge, and a LOG operand or memory cost beyond the
-				// cap halts REVM around its in-body topic+data charge, so both
-				// must be metered instead of skipped.
-				if evm.zkGasTracker != nil && evm.zkGasErr == nil && errors.Is(err, ErrGasUintOverflow) && zkGasStaticContextHaltsBeforeBody(op) {
-					evm.zkGasTracker.Begin(evm.depth, byte(op), gasBefore)
-					if zkErr := evm.zkGasTracker.FinishAndCharge(evm.depth, zkGasMemorySizeOverflowGasAfter(evm, op, stack, mem, gasBefore, gasAfterStatic)); zkErr != nil {
-						evm.setZkGasErr()
-						return nil, ErrZkGasLimitExceeded
+				// CHANGE(taiko): memory costs beyond go-ethereum's uint64 cap
+				// halt REVM around the affected opcode's in-body charges
+				// (initcode, topic+data, per-word, or memory expansion), so
+				// they must be metered instead of skipped.
+				if evm.zkGasTracker != nil && evm.zkGasErr == nil && errors.Is(err, ErrGasUintOverflow) {
+					if gasAfterOverflow, handled := zkGasDynamicUintOverflowGasAfter(evm, op, stack, mem, gasBefore, gasAfterStatic); handled {
+						evm.zkGasTracker.Begin(evm.depth, byte(op), gasBefore)
+						if zkErr := evm.zkGasTracker.FinishAndCharge(evm.depth, gasAfterOverflow); zkErr != nil {
+							evm.setZkGasErr()
+							return nil, ErrZkGasLimitExceeded
+						}
 					}
 				}
 				return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)

--- a/core/vm/taiko_zk_gas_runtime.go
+++ b/core/vm/taiko_zk_gas_runtime.go
@@ -259,13 +259,10 @@ func (t *ZkGasStepTracker) markSpawn(depth int, matches func(byte) bool) {
 // CHANGE(taiko): zkGasStaticContextHaltsBeforeBody reports opcodes whose REVM
 // instruction body halts on its static-context check before any in-body
 // charge, while go-ethereum surfaces the same failure only after computing
-// memory sizes or dynamic gas. The same opcodes are the ones whose operand and
-// memory-cost overflows REVM surfaces around those in-body charges (initcode
-// cost, topic+data cost) instead of after a fronted constant, so this
-// predicate also gates the in-body overflow reconstructions. SSTORE, TSTORE,
-// SELFDESTRUCT, and CALL with value fail earlier here — in the dynamic-gas
-// functions with ErrWriteProtection or in opcode execution — and never reach
-// the paths this predicate guards.
+// memory sizes or dynamic gas. SSTORE, TSTORE, SELFDESTRUCT, and CALL with
+// value fail earlier here — in the dynamic-gas functions with
+// ErrWriteProtection or in opcode execution — and never reach the paths this
+// predicate guards.
 func zkGasStaticContextHaltsBeforeBody(op OpCode) bool {
 	switch {
 	case op == CREATE || op == CREATE2:
@@ -276,6 +273,72 @@ func zkGasStaticContextHaltsBeforeBody(op OpCode) bool {
 	return false
 }
 
+// CHANGE(taiko): zkGasDynamicUintOverflowGasAfter resolves the REVM-mirroring
+// charge when a dynamic gas function fails with a uint64 overflow. go-ethereum
+// caps memory sizes inside memoryGasCost, while REVM prices any size with
+// saturating arithmetic and fails the resulting charge in its in-body order:
+// pre-memory word costs spend all remaining gas when unpayable, and the memory
+// expansion charge halts preserving gas. The boolean reports whether the
+// opcode has a mirrored reconstruction.
+func zkGasDynamicUintOverflowGasAfter(evm *EVM, op OpCode, stack *Stack, mem *Memory, gasBefore, gasAfterStatic uint64) (uint64, bool) {
+	switch {
+	case op == CREATE || op == CREATE2:
+		return zkGasCreateShortfallGasAfter(evm, stack, mem, gasBefore), true
+	case op >= LOG0 && op <= LOG4:
+		return zkGasLogShortfallGasAfter(evm, op, stack, mem, gasBefore), true
+	case op == KECCAK256 || op == CALLDATACOPY || op == CODECOPY || op == RETURNDATACOPY || op == MCOPY || op == EXTCODECOPY:
+		return zkGasCopyShortfallGasAfter(evm, op, stack, mem, gasBefore), true
+	case op == CALL || op == CALLCODE || op == DELEGATECALL || op == STATICCALL:
+		return zkGasCallShortfallGasAfter(evm, op, stack, mem, gasBefore), true
+	case op == MLOAD || op == MSTORE || op == MSTORE8 || op == RETURN || op == REVERT:
+		// No in-body charge precedes REVM's gas-preserving memory halt for
+		// these opcodes, so only the table static gas is visible.
+		return zkGasPreExecutionGasAfter(op, gasBefore), true
+	}
+	return gasAfterStatic, false
+}
+
+// CHANGE(taiko): zkGasCallShortfallGasAfter mirrors REVM's callback-visible
+// gas for CALL-family steps whose memory ranges fail before go-ethereum
+// charges dynamic gas. REVM resizes and charges the input range before the
+// output range, and every operand or expansion failure in either range halts
+// preserving gas, so an output-side failure keeps the input expansion charge
+// visible on top of the table static. A value-bearing CALL in a static frame
+// halts right after the three leading pops, before either memory range.
+func zkGasCallShortfallGasAfter(evm *EVM, op OpCode, stack *Stack, mem *Memory, gasBefore uint64) uint64 {
+	staticGas := zkGasRevmStaticGas[op]
+	if gasBefore < staticGas {
+		return 0
+	}
+	gas := gasBefore - staticGas
+	if op == CALL && evm.readOnly && !stack.Back(2).IsZero() {
+		return gas
+	}
+	inOffset, inSize, outOffset, outSize := 3, 4, 5, 6
+	if op == DELEGATECALL || op == STATICCALL {
+		inOffset, inSize, outOffset, outSize = 2, 3, 4, 5
+	}
+	currentMemorySize := uint64(mem.Len())
+	memoryLastGasCost := mem.lastGasCost
+	for _, memRange := range [2][2]int{{inOffset, inSize}, {outOffset, outSize}} {
+		memSize, overflow := calcMemSize64(stack.Back(memRange[0]), stack.Back(memRange[1]))
+		if overflow {
+			return gas
+		}
+		alignedMemSize, overflow := math.SafeMul(toWordSize(memSize), 32)
+		if overflow {
+			return gas
+		}
+		memoryCost, nextMemorySize, nextMemoryLastGasCost, ok := zkGasMemoryExpansionCost(currentMemorySize, memoryLastGasCost, alignedMemSize)
+		if !ok || gas < memoryCost {
+			return gas
+		}
+		gas -= memoryCost
+		currentMemorySize, memoryLastGasCost = nextMemorySize, nextMemoryLastGasCost
+	}
+	return gas
+}
+
 // CHANGE(taiko): zkGasDynamicOOGGasAfter mirrors REVM's callback-visible gas
 // for dynamic-cost shortfalls caught before go-ethereum executes the opcode.
 func zkGasDynamicOOGGasAfter(evm *EVM, op OpCode, stack *Stack, mem *Memory, memorySize, memoryLastGasCost, gasBefore, gasAfterStatic uint64) uint64 {
@@ -284,6 +347,11 @@ func zkGasDynamicOOGGasAfter(evm *EVM, op OpCode, stack *Stack, mem *Memory, mem
 	// only the table static gas.
 	if evm.readOnly && zkGasStaticContextHaltsBeforeBody(op) {
 		return zkGasPreExecutionGasAfter(op, gasBefore)
+	}
+	// RETURNDATACOPY validates its source range before REVM's copy charge, so
+	// its shortfall reconstruction must apply that bounds check first.
+	if op == RETURNDATACOPY {
+		return zkGasCopyShortfallGasAfter(evm, op, stack, mem, gasBefore)
 	}
 	preMemoryCost, gasBeforePreMemory, ok := zkGasPreMemoryCost(evm, op, stack, gasBefore, gasAfterStatic)
 	if !ok {
@@ -552,19 +620,94 @@ func zkGasLogShortfallGasAfter(evm *EVM, op OpCode, stack *Stack, mem *Memory, g
 	return gasAfterBody - memoryCost
 }
 
+// CHANGE(taiko): zkGasCopyShortfallGasAfter mirrors REVM's callback-visible
+// gas for KECCAK256 and copy-family steps that fail before go-ethereum charges
+// dynamic gas. REVM charges in instruction order: the table static in step(),
+// a gas-preserving halt on a length operand beyond 64 bits (and, for
+// RETURNDATACOPY, on a source range outside the return buffer), the saturating
+// per-word cost (spending all remaining gas when it cannot be paid), then
+// gas-preserving halts on offset operands and memory expansion. EXTCODECOPY's
+// trailing cold-access surcharge spends all remaining gas when it cannot be
+// paid.
+func zkGasCopyShortfallGasAfter(evm *EVM, op OpCode, stack *Stack, mem *Memory, gasBefore uint64) uint64 {
+	staticGas := zkGasRevmStaticGas[op]
+	if gasBefore < staticGas {
+		return 0
+	}
+	gasAfterStatic := gasBefore - staticGas
+	lenIndex, perWordGas := 2, params.CopyGas
+	switch op {
+	case KECCAK256:
+		lenIndex, perWordGas = 1, params.Keccak256WordGas
+	case EXTCODECOPY:
+		lenIndex = 3
+	}
+	size, overflow := stack.Back(lenIndex).Uint64WithOverflow()
+	if overflow {
+		return gasAfterStatic
+	}
+	if op == RETURNDATACOPY {
+		dataOffset, overflow := stack.Back(1).Uint64WithOverflow()
+		if overflow {
+			dataOffset = ^uint64(0)
+		}
+		dataEnd, overflow := math.SafeAdd(dataOffset, size)
+		if overflow || dataEnd > uint64(len(evm.returnData)) {
+			return gasAfterStatic
+		}
+	}
+	copyCost, ok := zkGasWordCost(stack.Back(lenIndex), perWordGas)
+	if !ok || gasAfterStatic < copyCost {
+		return 0
+	}
+	gasAfterCopy := gasAfterStatic - copyCost
+	memOffsetIndex := 0
+	if op == EXTCODECOPY {
+		memOffsetIndex = 1
+	}
+	memSize, overflow := calcMemSize64(stack.Back(memOffsetIndex), stack.Back(lenIndex))
+	if overflow {
+		return gasAfterCopy
+	}
+	if op == MCOPY {
+		srcSize, srcOverflow := calcMemSize64(stack.Back(1), stack.Back(lenIndex))
+		if srcOverflow {
+			return gasAfterCopy
+		}
+		if srcSize > memSize {
+			memSize = srcSize
+		}
+	}
+	alignedMemSize, overflow := math.SafeMul(toWordSize(memSize), 32)
+	if overflow {
+		return gasAfterCopy
+	}
+	memoryCost, _, _, ok := zkGasMemoryExpansionCost(uint64(mem.Len()), mem.lastGasCost, alignedMemSize)
+	if !ok || gasAfterCopy < memoryCost {
+		return gasAfterCopy
+	}
+	if op == EXTCODECOPY {
+		return 0
+	}
+	return gasAfterCopy - memoryCost
+}
+
 // CHANGE(taiko): zkGasMemorySizeOverflowGasAfter picks the REVM-mirroring
 // charge for memory-size operand overflows. Most opcodes surface these after
 // REVM already deducted its table static gas (matching go-ethereum's
-// constant-gas deduction), but CREATE-family operand overflows halt REVM
-// around its in-body initcode charge instead of the fronted 32000 base cost,
-// and LOG operand overflows halt REVM around its in-body topic+data charge
-// while go-ethereum fronts nothing.
+// constant-gas deduction), but CREATE-family, LOG, KECCAK256, and copy-family
+// operand overflows halt REVM around their in-body charges (initcode cost,
+// topic+data cost, per-word cost) instead of after a fronted constant.
 func zkGasMemorySizeOverflowGasAfter(evm *EVM, op OpCode, stack *Stack, mem *Memory, gasBefore, gasAfterStatic uint64) uint64 {
 	switch {
 	case op == CREATE || op == CREATE2:
 		return zkGasCreateShortfallGasAfter(evm, stack, mem, gasBefore)
 	case op >= LOG0 && op <= LOG4:
 		return zkGasLogShortfallGasAfter(evm, op, stack, mem, gasBefore)
+	case op == KECCAK256 || op == CALLDATACOPY || op == CODECOPY || op == RETURNDATACOPY || op == MCOPY || op == EXTCODECOPY:
+		return zkGasCopyShortfallGasAfter(evm, op, stack, mem, gasBefore)
+	case op == CALL || op == CALLCODE || op == DELEGATECALL || op == STATICCALL:
+		return zkGasCallShortfallGasAfter(evm, op, stack, mem, gasBefore)
 	}
 	return gasAfterStatic
 }
@@ -579,6 +722,11 @@ func zkGasStepGasAfter(op OpCode, err error, gasBefore, gasAfter uint64) uint64 
 	}
 	if err == ErrWriteProtection && op >= LOG0 && op <= LOG4 && gasBefore >= params.LogGas {
 		return gasBefore - params.LogGas
+	}
+	// REVM validates the return-data source range before charging its copy and
+	// memory costs, so only the table static gas is visible.
+	if err == ErrReturnDataOutOfBounds && op == RETURNDATACOPY {
+		return zkGasPreExecutionGasAfter(op, gasBefore)
 	}
 	// Opcodes REVM ships behind a fork gate Unzen does not enable execute as
 	// undefined opcodes here (no gas movement), but REVM deducts their table

--- a/core/vm/taiko_zk_gas_runtime.go
+++ b/core/vm/taiko_zk_gas_runtime.go
@@ -256,13 +256,34 @@ func (t *ZkGasStepTracker) markSpawn(depth int, matches func(byte) bool) {
 	}
 }
 
+// CHANGE(taiko): zkGasStaticContextHaltsBeforeBody reports opcodes whose REVM
+// instruction body halts on its static-context check before any in-body
+// charge, while go-ethereum surfaces the same failure only after computing
+// memory sizes or dynamic gas. The same opcodes are the ones whose operand and
+// memory-cost overflows REVM surfaces around those in-body charges (initcode
+// cost, topic+data cost) instead of after a fronted constant, so this
+// predicate also gates the in-body overflow reconstructions. SSTORE, TSTORE,
+// SELFDESTRUCT, and CALL with value fail earlier here — in the dynamic-gas
+// functions with ErrWriteProtection or in opcode execution — and never reach
+// the paths this predicate guards.
+func zkGasStaticContextHaltsBeforeBody(op OpCode) bool {
+	switch {
+	case op == CREATE || op == CREATE2:
+		return true
+	case op >= LOG0 && op <= LOG4:
+		return true
+	}
+	return false
+}
+
 // CHANGE(taiko): zkGasDynamicOOGGasAfter mirrors REVM's callback-visible gas
 // for dynamic-cost shortfalls caught before go-ethereum executes the opcode.
 func zkGasDynamicOOGGasAfter(evm *EVM, op OpCode, stack *Stack, mem *Memory, memorySize, memoryLastGasCost, gasBefore, gasAfterStatic uint64) uint64 {
-	// REVM's CREATE-family static-context check halts before any charge, so a
-	// dynamic-gas shortfall go-ethereum catches first must preserve the gas.
-	if (op == CREATE || op == CREATE2) && evm.readOnly {
-		return gasBefore
+	// REVM's static-context check for these opcodes halts before any in-body
+	// charge, so a dynamic-gas shortfall go-ethereum catches first must meter
+	// only the table static gas.
+	if evm.readOnly && zkGasStaticContextHaltsBeforeBody(op) {
+		return zkGasPreExecutionGasAfter(op, gasBefore)
 	}
 	preMemoryCost, gasBeforePreMemory, ok := zkGasPreMemoryCost(evm, op, stack, gasBefore, gasAfterStatic)
 	if !ok {
@@ -483,14 +504,67 @@ func zkGasCreate2SaltUnderflowGasAfter(evm *EVM, stack *Stack, mem *Memory, gasB
 	return gasAfter
 }
 
+// CHANGE(taiko): zkGasLogShortfallGasAfter mirrors REVM's callback-visible gas
+// for LOG steps that fail before go-ethereum charges dynamic gas. go-ethereum
+// fronts no constant gas for LOG, while REVM deducts the 375 table static in
+// step() and then charges in instruction order: the static-context check and a
+// length operand beyond 64 bits halt before the topic+data charge, the
+// saturating topic+data cost spends all remaining gas when it cannot be paid,
+// and offset-operand or memory-expansion failures halt preserving the gas left
+// after that charge.
+func zkGasLogShortfallGasAfter(evm *EVM, op OpCode, stack *Stack, mem *Memory, gasBefore uint64) uint64 {
+	if evm.readOnly {
+		return zkGasPreExecutionGasAfter(op, gasBefore)
+	}
+	staticGas := zkGasRevmStaticGas[op]
+	if gasBefore < staticGas {
+		return 0
+	}
+	gasAfterStatic := gasBefore - staticGas
+	size, overflow := stack.Back(1).Uint64WithOverflow()
+	if overflow {
+		return gasAfterStatic
+	}
+	dataGas, overflow := math.SafeMul(size, params.LogDataGas)
+	if overflow {
+		return 0
+	}
+	bodyCost, overflow := math.SafeAdd(uint64(op-LOG0)*params.LogTopicGas, dataGas)
+	if overflow || gasAfterStatic < bodyCost {
+		return 0
+	}
+	gasAfterBody := gasAfterStatic - bodyCost
+	if size == 0 {
+		return gasAfterBody
+	}
+	memSize, overflow := calcMemSize64(stack.Back(0), stack.Back(1))
+	if overflow {
+		return gasAfterBody
+	}
+	alignedMemSize, overflow := math.SafeMul(toWordSize(memSize), 32)
+	if overflow {
+		return gasAfterBody
+	}
+	memoryCost, _, _, ok := zkGasMemoryExpansionCost(uint64(mem.Len()), mem.lastGasCost, alignedMemSize)
+	if !ok || gasAfterBody < memoryCost {
+		return gasAfterBody
+	}
+	return gasAfterBody - memoryCost
+}
+
 // CHANGE(taiko): zkGasMemorySizeOverflowGasAfter picks the REVM-mirroring
 // charge for memory-size operand overflows. Most opcodes surface these after
 // REVM already deducted its table static gas (matching go-ethereum's
 // constant-gas deduction), but CREATE-family operand overflows halt REVM
-// around its in-body initcode charge instead of the fronted 32000 base cost.
+// around its in-body initcode charge instead of the fronted 32000 base cost,
+// and LOG operand overflows halt REVM around its in-body topic+data charge
+// while go-ethereum fronts nothing.
 func zkGasMemorySizeOverflowGasAfter(evm *EVM, op OpCode, stack *Stack, mem *Memory, gasBefore, gasAfterStatic uint64) uint64 {
-	if op == CREATE || op == CREATE2 {
+	switch {
+	case op == CREATE || op == CREATE2:
 		return zkGasCreateShortfallGasAfter(evm, stack, mem, gasBefore)
+	case op >= LOG0 && op <= LOG4:
+		return zkGasLogShortfallGasAfter(evm, op, stack, mem, gasBefore)
 	}
 	return gasAfterStatic
 }

--- a/core/vm/taiko_zk_gas_runtime_test.go
+++ b/core/vm/taiko_zk_gas_runtime_test.go
@@ -1798,3 +1798,382 @@ func TestUnzenZkGas_SstoreSentryChargesNothing(t *testing.T) {
 		})
 	}
 }
+
+func TestUnzenZkGas_MemoryCapOverflowMirrorsReferenceChargeOrder(t *testing.T) {
+	// Memory sizes beyond go-ethereum's memoryGasCost cap (0x1FFFFFFFE0) error
+	// in the dynamic gas functions, where the reference has no cap: it charges
+	// the table static in step(), any in-body word cost next (spending all
+	// remaining gas when unpayable), and halts gas-preserving on the memory
+	// expansion it can never afford.
+	for _, tt := range []struct {
+		name    string
+		op      OpCode
+		code    []byte
+		callGas uint64
+		wantErr error
+		want    uint64
+	}{
+		{
+			// Copy word cost for 2^41 bytes is unpayable: spends all.
+			name:    "keccak256 unpayable word cost spends all",
+			op:      KECCAK256,
+			code:    common.Hex2Bytes("6502000000000060002000"),
+			callGas: 100_000,
+			wantErr: ErrOutOfGas,
+			want:    99_994,
+		},
+		{
+			// Word cost for 0x20 bytes is paid, memory expansion is not.
+			name:    "keccak256 capped memory charges static and word gas",
+			op:      KECCAK256,
+			code:    common.Hex2Bytes("6020650200000000002000"),
+			callGas: 100_000,
+			wantErr: ErrOutOfGas,
+			want:    36,
+		},
+		{
+			name:    "calldatacopy capped memory charges static and copy gas",
+			op:      CALLDATACOPY,
+			code:    common.Hex2Bytes("60206000650200000000003700"),
+			callGas: 100_000,
+			wantErr: ErrOutOfGas,
+			want:    6,
+		},
+		{
+			name:    "codecopy capped memory charges static and copy gas",
+			op:      CODECOPY,
+			code:    common.Hex2Bytes("60206000650200000000003900"),
+			callGas: 100_000,
+			wantErr: ErrOutOfGas,
+			want:    6,
+		},
+		{
+			name:    "extcodecopy capped memory charges static and copy gas",
+			op:      EXTCODECOPY,
+			code:    append(append(common.Hex2Bytes("6020600065020000000000"), append([]byte{byte(PUSH20)}, make([]byte, 20)...)...), 0x3c, 0x00),
+			callGas: 100_000,
+			wantErr: ErrOutOfGas,
+			want:    103,
+		},
+		{
+			name:    "mcopy capped memory charges static and copy gas",
+			op:      MCOPY,
+			code:    common.Hex2Bytes("60206000650200000000005e00"),
+			callGas: 100_000,
+			wantErr: ErrOutOfGas,
+			want:    6,
+		},
+		{
+			name:    "mload capped memory charges static gas",
+			op:      MLOAD,
+			code:    common.Hex2Bytes("650200000000005100"),
+			callGas: 100_000,
+			wantErr: ErrOutOfGas,
+			want:    3,
+		},
+		{
+			name:    "mstore capped memory charges static gas",
+			op:      MSTORE,
+			code:    common.Hex2Bytes("6000650200000000005200"),
+			callGas: 100_000,
+			wantErr: ErrOutOfGas,
+			want:    3,
+		},
+		{
+			name:    "mstore8 capped memory charges static gas",
+			op:      MSTORE8,
+			code:    common.Hex2Bytes("6000650200000000005300"),
+			callGas: 100_000,
+			wantErr: ErrOutOfGas,
+			want:    3,
+		},
+		{
+			// RETURN's table static is zero, so the aligned charge is zero.
+			name:    "return capped memory charges nothing",
+			op:      RETURN,
+			code:    common.Hex2Bytes("602065020000000000f3"),
+			callGas: 100_000,
+			wantErr: ErrOutOfGas,
+			want:    0,
+		},
+		{
+			name:    "call capped output memory charges static gas",
+			op:      CALL,
+			code:    append(append(common.Hex2Bytes("60206502000000000060006000600073"), make([]byte, 20)...), 0x61, 0xff, 0xff, 0xf1, 0x00),
+			callGas: 100_000,
+			wantErr: ErrOutOfGas,
+			want:    100,
+		},
+		{
+			name:    "delegatecall capped output memory charges static gas",
+			op:      DELEGATECALL,
+			code:    append(append(common.Hex2Bytes("6020650200000000006000600073"), make([]byte, 20)...), 0x61, 0xff, 0xff, 0xf4, 0x00),
+			callGas: 100_000,
+			wantErr: ErrOutOfGas,
+			want:    100,
+		},
+		{
+			// The reference resizes and charges the input range before the
+			// output range, so a capped output preserves the input expansion.
+			name:    "call capped output after input expansion charges input memory",
+			op:      CALL,
+			code:    append(append(common.Hex2Bytes("60206502000000000060206000600073"), make([]byte, 20)...), 0x61, 0xff, 0xff, 0xf1, 0x00),
+			callGas: 100_000,
+			wantErr: ErrOutOfGas,
+			want:    103,
+		},
+		{
+			name:    "call capped output after two-word input expansion",
+			op:      CALL,
+			code:    append(append(common.Hex2Bytes("60206502000000000060406000600073"), make([]byte, 20)...), 0x61, 0xff, 0xff, 0xf1, 0x00),
+			callGas: 100_000,
+			wantErr: ErrOutOfGas,
+			want:    106,
+		},
+		{
+			name:    "delegatecall capped output after input expansion charges input memory",
+			op:      DELEGATECALL,
+			code:    append(append(common.Hex2Bytes("6020650200000000006020600073"), make([]byte, 20)...), 0x61, 0xff, 0xff, 0xf4, 0x00),
+			callGas: 100_000,
+			wantErr: ErrOutOfGas,
+			want:    103,
+		},
+		{
+			// A capped input range fails before anything beyond the static
+			// was charged.
+			name:    "call capped input memory charges static gas",
+			op:      CALL,
+			code:    append(append(common.Hex2Bytes("60006000602065020000000000600073"), make([]byte, 20)...), 0x61, 0xff, 0xff, 0xf1, 0x00),
+			callGas: 100_000,
+			wantErr: ErrOutOfGas,
+			want:    100,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			meter, evm := newOpcodeMirrorEVM(t, tt.code, nil, tt.op)
+
+			_, _, err := evm.Call(common.Address{}, spawnBoundaryOuterAddr, nil, tt.callGas, new(uint256.Int))
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Call err = %v, want %v", err, tt.wantErr)
+			}
+			if got := meter.TxZkGasUsed(); got != tt.want {
+				t.Fatalf("TxZkGasUsed = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnzenZkGas_CopyFamilyOperandOverflowChargesInBodyGas(t *testing.T) {
+	// A memory offset operand beyond 64 bits halts the reference only after
+	// its in-body word cost was charged, while the length operand halts before
+	// it. go-ethereum catches both in the same up-front memory-size check.
+	pushMax := "7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+	for _, tt := range []struct {
+		name string
+		op   OpCode
+		code []byte
+		want uint64
+	}{
+		{
+			name: "keccak256 offset overflow charges static and word gas",
+			op:   KECCAK256,
+			code: common.Hex2Bytes("6020" + pushMax[0:66] + "2000"),
+			want: 36,
+		},
+		{
+			name: "keccak256 length overflow charges static gas",
+			op:   KECCAK256,
+			code: common.Hex2Bytes(pushMax[0:66] + "60002000"),
+			want: 30,
+		},
+		{
+			name: "calldatacopy offset overflow charges static and copy gas",
+			op:   CALLDATACOPY,
+			code: common.Hex2Bytes("60206000" + pushMax[0:66] + "3700"),
+			want: 6,
+		},
+		{
+			name: "extcodecopy offset overflow charges static and copy gas",
+			op:   EXTCODECOPY,
+			code: append(append(common.Hex2Bytes("60206000"+pushMax[0:66]), append([]byte{byte(PUSH20)}, make([]byte, 20)...)...), 0x3c, 0x00),
+			want: 103,
+		},
+		{
+			name: "extcodecopy length overflow charges static gas",
+			op:   EXTCODECOPY,
+			code: append(append(common.Hex2Bytes(pushMax[0:66]+"60006000"), append([]byte{byte(PUSH20)}, make([]byte, 20)...)...), 0x3c, 0x00),
+			want: 100,
+		},
+		{
+			name: "mcopy source overflow charges static and copy gas",
+			op:   MCOPY,
+			code: common.Hex2Bytes("6020" + pushMax[0:66] + "60005e00"),
+			want: 6,
+		},
+		{
+			name: "mload offset overflow charges static gas",
+			op:   MLOAD,
+			code: common.Hex2Bytes(pushMax[0:66] + "5100"),
+			want: 3,
+		},
+		{
+			// Output-offset operand beyond 64 bits halts the reference after
+			// the input range was resized and charged.
+			name: "call output offset overflow after input expansion",
+			op:   CALL,
+			code: append(append(common.Hex2Bytes("6020"+pushMax[0:66]+"60206000600073"), make([]byte, 20)...), 0x61, 0xff, 0xff, 0xf1, 0x00),
+			want: 103,
+		},
+		{
+			name: "call input offset overflow charges static gas",
+			op:   CALL,
+			code: append(append(common.Hex2Bytes("600060006020"+pushMax[0:66]+"600073"), make([]byte, 20)...), 0x61, 0xff, 0xff, 0xf1, 0x00),
+			want: 100,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			meter, evm := newOpcodeMirrorEVM(t, tt.code, nil, tt.op)
+
+			_, _, err := evm.Call(common.Address{}, spawnBoundaryOuterAddr, nil, 100_000, new(uint256.Int))
+			if !errors.Is(err, ErrGasUintOverflow) {
+				t.Fatalf("Call err = %v, want %v", err, ErrGasUintOverflow)
+			}
+			if got := meter.TxZkGasUsed(); got != tt.want {
+				t.Fatalf("TxZkGasUsed = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnzenZkGas_ReturnDataCopyBoundsMirrorReferenceChargeOrder(t *testing.T) {
+	// The reference validates the return-data source range before charging its
+	// copy cost, so an out-of-bounds copy shows only the 3 table static —
+	// go-ethereum validates in execution, after charging copy and memory gas.
+	for _, tt := range []struct {
+		name    string
+		code    []byte
+		callGas uint64
+		wantErr error
+	}{
+		{
+			// All charges affordable; the bounds check fails in execution.
+			name:    "affordable out-of-bounds copy",
+			code:    common.Hex2Bytes("6020600060003e00"),
+			callGas: 100_000,
+			wantErr: ErrReturnDataOutOfBounds,
+		},
+		{
+			// Dynamic gas unaffordable, and the source range is also
+			// out of bounds: the reference bounds check fires first.
+			name:    "unaffordable out-of-bounds copy",
+			code:    common.Hex2Bytes("611000600063ffffffff3e00"),
+			callGas: 20_000,
+			wantErr: ErrOutOfGas,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			meter, evm := newOpcodeMirrorEVM(t, tt.code, nil, RETURNDATACOPY)
+
+			_, _, err := evm.Call(common.Address{}, spawnBoundaryOuterAddr, nil, tt.callGas, new(uint256.Int))
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Call err = %v, want %v", err, tt.wantErr)
+			}
+			if got := meter.TxZkGasUsed(); got != 3 {
+				t.Fatalf("TxZkGasUsed = %d, want 3", got)
+			}
+		})
+	}
+}
+
+func TestUnzenZkGas_MemoryShortfallAlignedWindowsRegression(t *testing.T) {
+	// Already-aligned windows pinned against accidental drift.
+	for _, tt := range []struct {
+		name    string
+		op      OpCode
+		code    []byte
+		callGas uint64
+		want    uint64
+	}{
+		{
+			// Unaffordable-memory reconstruction: static + word cost.
+			name:    "keccak256 unaffordable memory",
+			op:      KECCAK256,
+			code:    common.Hex2Bytes("602063ffffffff2000"),
+			callGas: 20_000,
+			want:    36,
+		},
+		{
+			// EXTCODECOPY fronted warm cost matches the reference static.
+			name:    "extcodecopy unaffordable memory",
+			op:      EXTCODECOPY,
+			code:    append(append(common.Hex2Bytes("6020600063ffffffff"), append([]byte{byte(PUSH20)}, make([]byte, 20)...)...), 0x3c, 0x00),
+			callGas: 20_000,
+			want:    103,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			meter, evm := newOpcodeMirrorEVM(t, tt.code, nil, tt.op)
+
+			_, _, err := evm.Call(common.Address{}, spawnBoundaryOuterAddr, nil, tt.callGas, new(uint256.Int))
+			if !errors.Is(err, ErrOutOfGas) {
+				t.Fatalf("Call err = %v, want %v", err, ErrOutOfGas)
+			}
+			if got := meter.TxZkGasUsed(); got != tt.want {
+				t.Fatalf("TxZkGasUsed = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnzenZkGas_StaticCallValueHaltsBeforeMemoryCharges(t *testing.T) {
+	innerAddr := common.HexToAddress("0x2000000000000000000000000000000000000000")
+	pushMax := "7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+	target := append([]byte{byte(PUSH20)}, make([]byte, 20)...)
+	tail := []byte{0x61, 0xff, 0xff}
+	for _, tt := range []struct {
+		name      string
+		op        OpCode
+		innerCode []byte
+		want      uint64
+	}{
+		{
+			// A value-bearing CALL in a static frame halts the reference
+			// right after its three leading pops, before the memory ranges
+			// are resized, so the input expansion must not be metered.
+			name:      "call with value halts at static gas",
+			op:        CALL,
+			innerCode: append(append(append(common.Hex2Bytes("6020"+pushMax+"602060006001"), target...), tail...), 0xf1, 0x00),
+			want:      100,
+		},
+		{
+			// Without value the reference proceeds into the memory ranges
+			// and charges the input expansion before the output halt.
+			name:      "call without value charges input memory",
+			op:        CALL,
+			innerCode: append(append(append(common.Hex2Bytes("6020"+pushMax+"602060006000"), target...), tail...), 0xf1, 0x00),
+			want:      103,
+		},
+		{
+			// CALLCODE may carry value in a static frame, so the reference
+			// also proceeds into the memory ranges.
+			name:      "callcode with value charges input memory",
+			op:        CALLCODE,
+			innerCode: append(append(append(common.Hex2Bytes("6020"+pushMax+"602060006001"), target...), tail...), 0xf2, 0x00),
+			want:      103,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			meter, evm := newOpcodeMirrorEVM(t, spawnBoundaryCallCodeWithGas(STATICCALL, innerAddr, 0xffff), map[common.Address][]byte{
+				innerAddr: tt.innerCode,
+			}, tt.op)
+
+			_, _, err := evm.Call(common.Address{}, spawnBoundaryOuterAddr, nil, 200_000, new(uint256.Int))
+			if err != nil {
+				t.Fatalf("Call returned error: %v", err)
+			}
+			if got := meter.TxZkGasUsed(); got != tt.want {
+				t.Fatalf("TxZkGasUsed = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/core/vm/taiko_zk_gas_runtime_test.go
+++ b/core/vm/taiko_zk_gas_runtime_test.go
@@ -2177,3 +2177,79 @@ func TestUnzenZkGas_StaticCallValueHaltsBeforeMemoryCharges(t *testing.T) {
 		})
 	}
 }
+
+func TestUnzenZkGas_LogTopicUnderflowMirrorsReferenceChargeOrder(t *testing.T) {
+	// REVM's LOG pops offset and length, charges the topic+data cost, resizes
+	// memory, and only then pops the topics — so a stack with the two memory
+	// operands but missing topics underflows with those charges collected and
+	// gas preserved. go-ethereum's up-front stack check fires before any of
+	// that and metered only the 375 table static.
+	for _, tt := range []struct {
+		name string
+		op   OpCode
+		code []byte
+		want uint64
+	}{
+		{
+			name: "log1 missing topic charges static and topic gas",
+			op:   LOG1,
+			code: common.Hex2Bytes("60006000a100"),
+			want: 750,
+		},
+		{
+			name: "log2 one topic short charges static and topic gas",
+			op:   LOG2,
+			code: common.Hex2Bytes("600060006000a200"),
+			want: 1_125,
+		},
+		{
+			name: "log4 missing topics charge static and topic gas",
+			op:   LOG4,
+			code: common.Hex2Bytes("60006000a400"),
+			want: 1_875,
+		},
+		{
+			// Nonzero length also collects the data and memory charges
+			// before the topic pop underflows.
+			name: "log1 missing topic with data charges memory too",
+			op:   LOG1,
+			code: common.Hex2Bytes("60206000a100"),
+			want: 1_009,
+		},
+		{
+			// With fewer than the two memory operands REVM underflows on its
+			// first pop, before any in-body charge.
+			name: "log1 single operand charges static gas",
+			op:   LOG1,
+			code: common.Hex2Bytes("6000a100"),
+			want: 375,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			meter, evm := newOpcodeMirrorEVM(t, tt.code, nil, tt.op)
+
+			_, _, err := evm.Call(common.Address{}, spawnBoundaryOuterAddr, nil, 100_000, new(uint256.Int))
+			if v := (*ErrStackUnderflow)(nil); !errors.As(err, &v) {
+				t.Fatalf("Call err = %v, want stack underflow", err)
+			}
+			if got := meter.TxZkGasUsed(); got != tt.want {
+				t.Fatalf("TxZkGasUsed = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnzenZkGas_LogTopicUnderflowInStaticContextChargesStaticGas(t *testing.T) {
+	innerAddr := common.HexToAddress("0x2000000000000000000000000000000000000000")
+	meter, evm := newOpcodeMirrorEVM(t, spawnBoundaryCallCodeWithGas(STATICCALL, innerAddr, 0xffff), map[common.Address][]byte{
+		innerAddr: common.Hex2Bytes("60006000a100"),
+	}, LOG1)
+
+	_, _, err := evm.Call(common.Address{}, spawnBoundaryOuterAddr, nil, 200_000, new(uint256.Int))
+	if err != nil {
+		t.Fatalf("Call returned error: %v", err)
+	}
+	if got := meter.TxZkGasUsed(); got != 375 {
+		t.Fatalf("TxZkGasUsed = %d, want 375 for a static-context LOG1 topic underflow", got)
+	}
+}

--- a/core/vm/taiko_zk_gas_runtime_test.go
+++ b/core/vm/taiko_zk_gas_runtime_test.go
@@ -1291,12 +1291,20 @@ func TestUnzenZkGas_CreateSpawnLimitLeavesCreatedAccountUntouched(t *testing.T) 
 
 func newCreateShortfallEVM(t *testing.T, outerCode []byte, extraContracts map[common.Address][]byte) (*ZkGasMeter, *EVM) {
 	t.Helper()
+	return newOpcodeMirrorEVM(t, outerCode, extraContracts, CREATE, CREATE2)
+}
+
+// newOpcodeMirrorEVM builds a metered EVM whose schedule counts only the given
+// opcodes (multiplier 1), so a test's TxZkGasUsed isolates their charges.
+func newOpcodeMirrorEVM(t *testing.T, outerCode []byte, extraContracts map[common.Address][]byte, meteredOps ...OpCode) (*ZkGasMeter, *EVM) {
+	t.Helper()
 
 	schedule := &ZkGasSchedule{BlockLimit: 1 << 40}
 	schedule.SpawnEstimates.Create = 37_000
 	schedule.SpawnEstimates.Create2 = 44_500
-	schedule.OpcodeMultipliers[byte(CREATE)] = 1
-	schedule.OpcodeMultipliers[byte(CREATE2)] = 1
+	for _, op := range meteredOps {
+		schedule.OpcodeMultipliers[byte(op)] = 1
+	}
 
 	rules := params.MergedTestChainConfig.Rules(big.NewInt(1), true, 1)
 	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
@@ -1604,5 +1612,189 @@ func TestUnzenZkGas_Create2SaltUnderflowInStaticContextChargesNothing(t *testing
 	}
 	if got := meter.TxZkGasUsed(); got != 0 {
 		t.Fatalf("TxZkGasUsed = %d, want 0 for a static-context CREATE2 salt underflow", got)
+	}
+}
+
+func TestUnzenZkGas_LogShortfallMirrorsReferenceChargeOrder(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		op      OpCode
+		code    []byte
+		callGas uint64
+		wantErr error
+		want    uint64
+	}{
+		{
+			// Length operand beyond 64 bits halts the reference before its
+			// topic+data charge, preserving gas: only the 375 static counts.
+			name:    "log0 length overflow charges static gas",
+			op:      LOG0,
+			code:    common.Hex2Bytes("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff6000a000"),
+			callGas: 100_000,
+			wantErr: ErrGasUintOverflow,
+			want:    375,
+		},
+		{
+			// Offset operand beyond 64 bits halts after the topic+data charge
+			// (8*0x20 = 256), preserving gas.
+			name:    "log0 offset overflow charges static and data gas",
+			op:      LOG0,
+			code:    common.Hex2Bytes("60207fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa000"),
+			callGas: 100_000,
+			wantErr: ErrGasUintOverflow,
+			want:    631,
+		},
+		{
+			// Same as above with one topic: 375 static + 375 topic + 256 data.
+			name:    "log1 offset overflow includes topic gas",
+			op:      LOG1,
+			code:    common.Hex2Bytes("600060207fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa100"),
+			callGas: 100_000,
+			wantErr: ErrGasUintOverflow,
+			want:    1006,
+		},
+		{
+			// Memory size beyond go-ethereum's cost cap errors in the dynamic
+			// gas function; the reference charges topic+data, then halts
+			// preserving on the memory expansion.
+			name:    "log0 memory cost cap charges static and data gas",
+			op:      LOG0,
+			code:    common.Hex2Bytes("602065020000000000a000"),
+			callGas: 100_000,
+			wantErr: ErrOutOfGas,
+			want:    631,
+		},
+		{
+			// A data cost beyond 64 bits saturates in the reference and the
+			// failed charge spends all remaining gas.
+			name:    "log0 saturating data cost spends all",
+			op:      LOG0,
+			code:    common.Hex2Bytes("6740000000000000006000a000"),
+			callGas: 100_000,
+			wantErr: ErrOutOfGas,
+			want:    99_994,
+		},
+		{
+			// Affordable topic+data but unaffordable memory expansion: the
+			// pre-existing reconstruction path, kept as a regression.
+			name:    "log0 unaffordable memory charges static and data gas",
+			op:      LOG0,
+			code:    common.Hex2Bytes("602063ffffffffa000"),
+			callGas: 20_000,
+			wantErr: ErrOutOfGas,
+			want:    631,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			meter, evm := newOpcodeMirrorEVM(t, tt.code, nil, tt.op)
+
+			_, _, err := evm.Call(common.Address{}, spawnBoundaryOuterAddr, nil, tt.callGas, new(uint256.Int))
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Call err = %v, want %v", err, tt.wantErr)
+			}
+			if got := meter.TxZkGasUsed(); got != tt.want {
+				t.Fatalf("TxZkGasUsed = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnzenZkGas_LogInStaticContextChargesStaticGas(t *testing.T) {
+	innerAddr := common.HexToAddress("0x2000000000000000000000000000000000000000")
+	for _, tt := range []struct {
+		name      string
+		op        OpCode
+		innerCode []byte
+	}{
+		// The reference halts every static-context LOG on its write-protection
+		// check before any in-body charge, so only the 375 table static (paid
+		// before the instruction body) is visible, regardless of which
+		// go-ethereum guard catches the failure first.
+		{
+			name:      "unaffordable memory",
+			op:        LOG0,
+			innerCode: common.Hex2Bytes("61100063ffffffffa000"),
+		},
+		{
+			name:      "unaffordable memory with topics",
+			op:        LOG2,
+			innerCode: common.Hex2Bytes("6000600061100063ffffffffa200"),
+		},
+		{
+			name:      "length overflow",
+			op:        LOG0,
+			innerCode: common.Hex2Bytes("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff6000a000"),
+		},
+		{
+			name:      "memory cost cap",
+			op:        LOG0,
+			innerCode: common.Hex2Bytes("602065020000000000a000"),
+		},
+		{
+			name:      "affordable write protection",
+			op:        LOG0,
+			innerCode: common.Hex2Bytes("60206000a000"),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			meter, evm := newOpcodeMirrorEVM(t, spawnBoundaryCallCodeWithGas(STATICCALL, innerAddr, 0xffff), map[common.Address][]byte{
+				innerAddr: tt.innerCode,
+			}, tt.op)
+
+			_, _, err := evm.Call(common.Address{}, spawnBoundaryOuterAddr, nil, 200_000, new(uint256.Int))
+			if err != nil {
+				t.Fatalf("Call returned error: %v", err)
+			}
+			if got, want := meter.TxZkGasUsed(), zkGasRevmStaticGas[tt.op]; got != want {
+				t.Fatalf("TxZkGasUsed = %d, want %d for a static-context %v", got, want, tt.op)
+			}
+		})
+	}
+}
+
+func TestUnzenZkGas_TstoreInStaticContextChargesStaticGas(t *testing.T) {
+	innerAddr := common.HexToAddress("0x2000000000000000000000000000000000000000")
+	innerCode := common.Hex2Bytes("600060005d00")
+	meter, evm := newOpcodeMirrorEVM(t, spawnBoundaryCallCodeWithGas(STATICCALL, innerAddr, 0xffff), map[common.Address][]byte{
+		innerAddr: innerCode,
+	}, TSTORE)
+
+	_, _, err := evm.Call(common.Address{}, spawnBoundaryOuterAddr, nil, 200_000, new(uint256.Int))
+	if err != nil {
+		t.Fatalf("Call returned error: %v", err)
+	}
+	if got, want := meter.TxZkGasUsed(), zkGasRevmStaticGas[TSTORE]; got != want {
+		t.Fatalf("TxZkGasUsed = %d, want %d for a static-context TSTORE", got, want)
+	}
+}
+
+func TestUnzenZkGas_SstoreSentryChargesNothing(t *testing.T) {
+	innerAddr := common.HexToAddress("0x2000000000000000000000000000000000000000")
+	innerCode := common.Hex2Bytes("600160005500")
+	for _, tt := range []struct {
+		name  string
+		outer []byte
+	}{
+		// Reentrancy sentry: the child frame holds exactly 2300 gas at the
+		// SSTORE, tripping the EIP-2200 sentry in the dynamic gas function.
+		// The reference halts gas-preserving after its zero table static.
+		{"sentry", spawnBoundaryCallCodeWithGas(CALL, innerAddr, 2306)},
+		// Static context: the dynamic gas function fails with write
+		// protection, which meters the zero table static.
+		{"static context", spawnBoundaryCallCodeWithGas(STATICCALL, innerAddr, 0xffff)},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			meter, evm := newOpcodeMirrorEVM(t, tt.outer, map[common.Address][]byte{
+				innerAddr: innerCode,
+			}, SSTORE)
+
+			_, _, err := evm.Call(common.Address{}, spawnBoundaryOuterAddr, nil, 200_000, new(uint256.Int))
+			if err != nil {
+				t.Fatalf("Call returned error: %v", err)
+			}
+			if got := meter.TxZkGasUsed(); got != 0 {
+				t.Fatalf("TxZkGasUsed = %d, want 0 for an SSTORE %s failure", got, tt.name)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up to #588/#589, closing the last confirmed read-only zk-gas divergence against the alethia-reth/revm reference — LOG opcodes — plus the LOG operand-overflow windows that share the same root cause.

geth fronts no constant gas for LOG, while revm deducts the 375 table static centrally in `step()` (revm-interpreter 35.0.1 `interpreter.rs:300`) and charges the topic+data cost inside the `log` instruction behind `require_non_staticcall!` (`host.rs:327-334`, gas-preserving halts; `log_cost` saturates). geth's readOnly check for LOG sits in `makeLog` (execute phase), so every failure caught before execution metered a different value than the reference:

| Window | geth before | reference |
|---|---|---|
| readOnly, unaffordable dynamic gas (e.g. `LOG0(offset=0xffffffff, len=0x1000)` behind STATICCALL) | 33,143 | 375 |
| readOnly, operand overflow / memory cost cap | 0 | 375 |
| length operand > 64 bits | 0 | 375 |
| offset operand > 64 bits / memory cost beyond cap (len=0x20) | 0 | 631 (+375/topic) |
| data cost > 64 bits (saturating charge fails) | 0 | all remaining gas |

Divergent per-step zk-gas diverges block totals → Unzen `header.difficulty` (enforced on import by both clients) and the tx-list truncation point → mutual block rejection. Reachable by any transaction.

## Changes

- `core/vm/taiko_zk_gas_runtime.go`: generalize #588's readOnly guard into `zkGasStaticContextHaltsBeforeBody` (CREATE family + LOG family; identical behavior for CREATE) and apply it in `zkGasDynamicOOGGasAfter`; add `zkGasLogShortfallGasAfter` mirroring REVM's in-body charge order (static → length check → saturating topic+data → offset/memory, gas-preserving); route LOG through `zkGasMemorySizeOverflowGasAfter`.
- `core/vm/interpreter.go`: meter LOG (alongside CREATE) when the dynamic-gas function fails with a uint overflow, via the shared overflow dispatcher.
- `core/vm/taiko_zk_gas_runtime_test.go`: red/green regressions for all divergent windows (LOG0/LOG1/LOG2), plus pins for the already-aligned neighbours: unaffordable-memory reconstruction (631), execute-phase LOG write protection (375), static-context TSTORE (100), SSTORE reentrancy sentry and static-context (0). New `newOpcodeMirrorEVM` helper generalizes `newCreateShortfallEVM`.

Verified (fix only if divergent) per the follow-up plan: execute-phase LOG write protection, TSTORE (100 via the measured default), and both SSTORE windows were already aligned — now covered by regressions. SSTORE's readOnly check precedes its sentry check in the dynamic-gas functions, matching the reference's check order; both meter 0 either way.

Out of scope, tracked separately: non-CREATE/LOG opcodes whose memory cost exceeds geth's uint64 cap (e.g. KECCAK256 with extreme operands) currently meter 0 on the dynamic-gas error path; whether the reference's in-body order diverges there needs its own opcode-by-opcode mapping.

## Test Plan

- [x] `go test ./core/vm -run 'TestUnzenZkGas_(LogShortfallMirrorsReferenceChargeOrder|LogInStaticContextChargesStaticGas|TstoreInStaticContextChargesStaticGas|SstoreSentryChargesNothing)' -v` (all red before the fix except the pinned-aligned cases)
- [x] `go test ./core/vm -count=1`
- [x] `go test ./core/... ./miner/... ./consensus/taiko/... ./eth/tracers/...`
- [x] `gofmt -s -l core/vm/` clean, `go vet ./core/vm/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)