### PR TITLE
chore(core,vm): align system-call semantics and harden zk-gas couplings

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -159,7 +159,15 @@ func (p *StateProcessor) Process(ctx context.Context, block *types.Block, stated
 
 		// CHANGE(taiko): commit transaction zk gas on success.
 		if cfg.ZkGasMeter != nil {
-			if commitErr := cfg.ZkGasMeter.CommitTransaction(); commitErr != nil && i > 0 {
+			if commitErr := cfg.ZkGasMeter.CommitTransaction(); commitErr != nil {
+				// The anchor can never be truncated: fail the block like the
+				// reference executor does instead of committing a body the
+				// reference rejects. Unreachable in practice, since charging
+				// already bounds committed+in-flight zk gas to the block limit.
+				if i == 0 {
+					spanEnd(&commitErr)
+					return nil, fmt.Errorf("could not apply anchor tx [%v]: %w", tx.Hash().Hex(), commitErr)
+				}
 				cfg.ZkGasMeter.ResetTransaction()
 				spanEnd(nil)
 				break
@@ -354,6 +362,20 @@ func ApplyTransaction(evm *vm.EVM, gp *GasPool, statedb *state.StateDB, header *
 	return ApplyTransactionWithEVM(msg, gp, statedb, header.Number, header.Hash(), header.Time, tx, evm)
 }
 
+// CHANGE(taiko): systemCallGasLimit returns the gas limit for EVM system
+// calls. The reference execution client caps every system call at the
+// EIP-7825 transaction gas cap, so Taiko chains observe the same cap should
+// code ever exist at a system address. Only the cap is aligned: the
+// reference runs system calls as full inner transactions (intrinsic gas
+// deducted inside the cap, block-env gas limit and basefee swapped for the
+// call) — residual differences no canonical system contract observes.
+func systemCallGasLimit(config *params.ChainConfig) uint64 {
+	if config.Taiko {
+		return params.MaxTxGas
+	}
+	return 30_000_000
+}
+
 // ProcessBeaconBlockRoot applies the EIP-4788 system call to the beacon block root
 // contract. This method is exported to be used in tests.
 func ProcessBeaconBlockRoot(beaconRoot common.Hash, evm *vm.EVM) {
@@ -363,9 +385,11 @@ func ProcessBeaconBlockRoot(beaconRoot common.Hash, evm *vm.EVM) {
 			defer tracer.OnSystemCallEnd()
 		}
 	}
+	// CHANGE(taiko): observe the reference client's system-call gas limit.
+	gasLimit := systemCallGasLimit(evm.ChainConfig())
 	msg := &Message{
 		From:      params.SystemAddress,
-		GasLimit:  30_000_000,
+		GasLimit:  gasLimit,
 		GasPrice:  common.Big0,
 		GasFeeCap: common.Big0,
 		GasTipCap: common.Big0,
@@ -374,7 +398,7 @@ func ProcessBeaconBlockRoot(beaconRoot common.Hash, evm *vm.EVM) {
 	}
 	evm.SetTxContext(NewEVMTxContext(msg))
 	evm.StateDB.AddAddressToAccessList(params.BeaconRootsAddress)
-	_, _, _ = evm.Call(msg.From, *msg.To, msg.Data, 30_000_000, common.U2560)
+	_, _, _ = evm.Call(msg.From, *msg.To, msg.Data, gasLimit, common.U2560)
 	evm.StateDB.Finalise(true)
 }
 
@@ -387,9 +411,11 @@ func ProcessParentBlockHash(prevHash common.Hash, evm *vm.EVM) {
 			defer tracer.OnSystemCallEnd()
 		}
 	}
+	// CHANGE(taiko): observe the reference client's system-call gas limit.
+	gasLimit := systemCallGasLimit(evm.ChainConfig())
 	msg := &Message{
 		From:      params.SystemAddress,
-		GasLimit:  30_000_000,
+		GasLimit:  gasLimit,
 		GasPrice:  common.Big0,
 		GasFeeCap: common.Big0,
 		GasTipCap: common.Big0,
@@ -398,7 +424,7 @@ func ProcessParentBlockHash(prevHash common.Hash, evm *vm.EVM) {
 	}
 	evm.SetTxContext(NewEVMTxContext(msg))
 	evm.StateDB.AddAddressToAccessList(params.HistoryStorageAddress)
-	_, _, err := evm.Call(msg.From, *msg.To, msg.Data, 30_000_000, common.U2560)
+	_, _, err := evm.Call(msg.From, *msg.To, msg.Data, gasLimit, common.U2560)
 	if err != nil {
 		panic(err)
 	}
@@ -421,6 +447,14 @@ func ProcessConsolidationQueue(requests *[][]byte, evm *vm.EVM) error {
 }
 
 func processRequestsSystemCall(requests *[][]byte, evm *vm.EVM, requestType byte, addr common.Address) error {
+	// CHANGE(taiko): the reference execution client never runs the
+	// EIP-7002/7251 request-queue system calls — Taiko blocks pin the empty
+	// requests hash — so skip them on every path (import, sealing, and test
+	// chain generation) to keep the state transition identical should code
+	// ever exist at the queue addresses.
+	if evm.ChainConfig().Taiko {
+		return nil
+	}
 	if tracer := evm.Config.Tracer; tracer != nil {
 		onSystemCallStart(tracer, evm.GetVMContext())
 		if tracer.OnSystemCallEnd != nil {
@@ -433,9 +467,11 @@ func processRequestsSystemCall(requests *[][]byte, evm *vm.EVM, requestType byte
 		defer evm.Config.ZkGasMeter.ResetTransaction()
 		defer evm.ResetZkGasErr()
 	}
+	// CHANGE(taiko): observe the reference client's system-call gas limit.
+	gasLimit := systemCallGasLimit(evm.ChainConfig())
 	msg := &Message{
 		From:      params.SystemAddress,
-		GasLimit:  30_000_000,
+		GasLimit:  gasLimit,
 		GasPrice:  common.Big0,
 		GasFeeCap: common.Big0,
 		GasTipCap: common.Big0,
@@ -443,7 +479,7 @@ func processRequestsSystemCall(requests *[][]byte, evm *vm.EVM, requestType byte
 	}
 	evm.SetTxContext(NewEVMTxContext(msg))
 	evm.StateDB.AddAddressToAccessList(addr)
-	ret, _, err := evm.Call(msg.From, *msg.To, msg.Data, 30_000_000, common.U2560)
+	ret, _, err := evm.Call(msg.From, *msg.To, msg.Data, gasLimit, common.U2560)
 	evm.StateDB.Finalise(true)
 	if err != nil {
 		return fmt.Errorf("system call failed to execute: %v", err)

--- a/core/taiko_state_processor_unzen_test.go
+++ b/core/taiko_state_processor_unzen_test.go
@@ -315,3 +315,99 @@ func TestApplyTransactionWithEVM_Unzen_IncludesTxIntrinsicInBlockZkGas(t *testin
 		t.Fatalf("BlockZkGasUsed after value transfer = %d, want %d (intrinsic only)", got, vm.TxIntrinsicZkGas)
 	}
 }
+
+// CHANGE(taiko): taikoSystemCallTestBlockContext returns a minimal block
+// context for exercising the system-call helpers directly.
+func taikoSystemCallTestBlockContext() vm.BlockContext {
+	return vm.BlockContext{
+		CanTransfer: CanTransfer,
+		Transfer:    Transfer,
+		GetHash:     func(uint64) common.Hash { return common.Hash{} },
+		BlockNumber: big.NewInt(1),
+		Time:        1,
+		Difficulty:  big.NewInt(0),
+		BaseFee:     big.NewInt(0),
+		GasLimit:    30_000_000,
+		Random:      &common.Hash{},
+		BlobBaseFee: big.NewInt(1),
+	}
+}
+
+// CHANGE(taiko): the reference execution client never runs the EIP-7002/7251
+// request-queue system calls for Taiko blocks — the requests hash is pinned
+// empty — so the queue processors must skip execution even when code exists at
+// the queue addresses.
+func TestTaikoSkipsRequestQueueSystemCalls(t *testing.T) {
+	// Returns a single byte, so a call that does execute appends one request.
+	queueCode := common.Hex2Bytes("60016000526001601ff3")
+	for _, tt := range []struct {
+		name         string
+		taiko        bool
+		wantRequests int
+	}{
+		{"taiko skips queue calls", true, 0},
+		{"upstream still processes queue calls", false, 2},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			config := unzenTestChainConfig(t)
+			if !tt.taiko {
+				cfg := *params.MergedTestChainConfig
+				config = &cfg
+			}
+			statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+			statedb.SetCode(params.WithdrawalQueueAddress, queueCode, tracing.CodeChangeGenesis)
+			statedb.SetCode(params.ConsolidationQueueAddress, queueCode, tracing.CodeChangeGenesis)
+			statedb.Finalise(true)
+
+			evm := vm.NewEVM(taikoSystemCallTestBlockContext(), statedb, config, vm.Config{})
+			requests := [][]byte{}
+			if err := ProcessWithdrawalQueue(&requests, evm); err != nil {
+				t.Fatalf("ProcessWithdrawalQueue: %v", err)
+			}
+			if err := ProcessConsolidationQueue(&requests, evm); err != nil {
+				t.Fatalf("ProcessConsolidationQueue: %v", err)
+			}
+			if len(requests) != tt.wantRequests {
+				t.Fatalf("requests = %d, want %d", len(requests), tt.wantRequests)
+			}
+		})
+	}
+}
+
+// CHANGE(taiko): the reference execution client caps every system call at the
+// EIP-7825 transaction gas cap; pin go-ethereum's Taiko system calls to the
+// same cap. (Only the cap is aligned — see systemCallGasLimit.)
+func TestTaikoSystemCallGasLimitMatchesReference(t *testing.T) {
+	// GAS PUSH0 SSTORE STOP: stores the observed gas into slot 0.
+	gasProbe := common.Hex2Bytes("5a5f5500")
+	for _, tt := range []struct {
+		name  string
+		taiko bool
+		want  uint64
+	}{
+		{"taiko caps at the eip-7825 limit", true, params.MaxTxGas - 2},
+		{"upstream keeps 30m", false, 30_000_000 - 2},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			config := unzenTestChainConfig(t)
+			if !tt.taiko {
+				cfg := *params.MergedTestChainConfig
+				config = &cfg
+			}
+			statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+			statedb.SetCode(params.BeaconRootsAddress, gasProbe, tracing.CodeChangeGenesis)
+			statedb.SetCode(params.HistoryStorageAddress, gasProbe, tracing.CodeChangeGenesis)
+			statedb.Finalise(true)
+
+			evm := vm.NewEVM(taikoSystemCallTestBlockContext(), statedb, config, vm.Config{})
+			ProcessBeaconBlockRoot(common.Hash{}, evm)
+			if got := statedb.GetState(params.BeaconRootsAddress, common.Hash{}).Big().Uint64(); got != tt.want {
+				t.Fatalf("beacon-root system call observed gas = %d, want %d", got, tt.want)
+			}
+			ProcessParentBlockHash(common.Hash{}, evm)
+			if got := statedb.GetState(params.HistoryStorageAddress, common.Hash{}).Big().Uint64(); got != tt.want {
+				t.Fatalf("parent-hash system call observed gas = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/core/vm/errors.go
+++ b/core/vm/errors.go
@@ -42,6 +42,12 @@ var (
 	// errStopToken is an internal token indicating interpreter loop termination,
 	// never returned to outside callers.
 	errStopToken = errors.New("stop token")
+
+	// CHANGE(taiko): errSStoreSentry is the EIP-2200 minimum-gas failure
+	// surfaced by the SSTORE dynamic gas functions. It is a sentinel so the
+	// interpreter's zk-gas metering can recognize the failure class instead
+	// of silently skipping the step (see interpreter.go).
+	errSStoreSentry = errors.New("not enough gas for reentrancy sentry")
 )
 
 // ErrStackUnderflow wraps an evm error when the items on the stack less

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -17,8 +17,6 @@
 package vm
 
 import (
-	"errors"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/params"
@@ -188,7 +186,8 @@ func gasSStoreEIP2200(evm *EVM, contract *Contract, stack *Stack, mem *Memory, m
 	}
 	// If we fail the minimum gas availability invariant, fail (0)
 	if contract.Gas <= params.SstoreSentryGasEIP2200 {
-		return 0, errors.New("not enough gas for reentrancy sentry")
+		// CHANGE(taiko): sentinel error so zk-gas metering recognizes the class.
+		return 0, errSStoreSentry
 	}
 	// Gas sentry honoured, do the actual gas calculation based on the stored value
 	var (

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -299,32 +299,49 @@ func (evm *EVM) Run(contract *Contract, input []byte, readOnly bool) (ret []byte
 			dynamicCost, err = operation.dynamicGas(evm, contract, stack, mem, memorySize)
 			cost += dynamicCost // for tracing
 			if err != nil {
-				if evm.zkGasTracker != nil && evm.zkGasErr == nil && errors.Is(err, ErrOutOfGas) {
-					evm.zkGasTracker.Begin(evm.depth, byte(op), gasBefore)
-					if zkErr := evm.zkGasTracker.FinishAndCharge(evm.depth, zkGasDynamicOOGGasAfter(evm, op, stack, mem, memorySize, memoryLastGasCost, gasBefore, gasAfterStatic)); zkErr != nil {
-						evm.setZkGasErr()
-						return nil, ErrZkGasLimitExceeded
-					}
-				}
-				// CHANGE(taiko): dynamic-gas write-protection failures occur
-				// before go-ethereum reaches opcode execution. REVM has already
-				// deducted the instruction-table static gas at that point, so
-				// mirror the same pre-execution charge here.
-				if evm.zkGasTracker != nil && evm.zkGasErr == nil && errors.Is(err, ErrWriteProtection) {
-					evm.zkGasTracker.Begin(evm.depth, byte(op), gasBefore)
-					if zkErr := evm.zkGasTracker.FinishAndCharge(evm.depth, zkGasPreExecutionGasAfter(op, gasBefore)); zkErr != nil {
-						evm.setZkGasErr()
-						return nil, ErrZkGasLimitExceeded
-					}
-				}
-				// CHANGE(taiko): memory costs beyond go-ethereum's uint64 cap
-				// halt REVM around the affected opcode's in-body charges
-				// (initcode, topic+data, per-word, or memory expansion), so
-				// they must be metered instead of skipped.
-				if evm.zkGasTracker != nil && evm.zkGasErr == nil && errors.Is(err, ErrGasUintOverflow) {
-					if gasAfterOverflow, handled := zkGasDynamicUintOverflowGasAfter(evm, op, stack, mem, gasBefore, gasAfterStatic); handled {
+				// CHANGE(taiko): reconstruct the REVM-visible spend for the
+				// dynamic-gas failure class. The classes are mutually
+				// exclusive, and the switch guarantees a step can never be
+				// metered twice even if a future gas function wraps several
+				// of them into one error.
+				if evm.zkGasTracker != nil && evm.zkGasErr == nil {
+					switch {
+					case errors.Is(err, ErrOutOfGas):
 						evm.zkGasTracker.Begin(evm.depth, byte(op), gasBefore)
-						if zkErr := evm.zkGasTracker.FinishAndCharge(evm.depth, gasAfterOverflow); zkErr != nil {
+						if zkErr := evm.zkGasTracker.FinishAndCharge(evm.depth, zkGasDynamicOOGGasAfter(evm, op, stack, mem, memorySize, memoryLastGasCost, gasBefore, gasAfterStatic)); zkErr != nil {
+							evm.setZkGasErr()
+							return nil, ErrZkGasLimitExceeded
+						}
+					case errors.Is(err, ErrWriteProtection):
+						// Write-protection failures occur before go-ethereum
+						// reaches opcode execution. REVM has already deducted
+						// the instruction-table static gas at that point, so
+						// mirror the same pre-execution charge here.
+						evm.zkGasTracker.Begin(evm.depth, byte(op), gasBefore)
+						if zkErr := evm.zkGasTracker.FinishAndCharge(evm.depth, zkGasPreExecutionGasAfter(op, gasBefore)); zkErr != nil {
+							evm.setZkGasErr()
+							return nil, ErrZkGasLimitExceeded
+						}
+					case errors.Is(err, ErrGasUintOverflow):
+						// Memory costs beyond go-ethereum's uint64 cap halt
+						// REVM around the affected opcode's in-body charges
+						// (initcode, topic+data, per-word, or memory
+						// expansion), so they must be metered instead of
+						// skipped.
+						if gasAfterOverflow, handled := zkGasDynamicUintOverflowGasAfter(evm, op, stack, mem, gasBefore, gasAfterStatic); handled {
+							evm.zkGasTracker.Begin(evm.depth, byte(op), gasBefore)
+							if zkErr := evm.zkGasTracker.FinishAndCharge(evm.depth, gasAfterOverflow); zkErr != nil {
+								evm.setZkGasErr()
+								return nil, ErrZkGasLimitExceeded
+							}
+						}
+					case errors.Is(err, errSStoreSentry), errors.Is(err, ErrMaxInitCodeSizeExceeded):
+						// The SSTORE reentrancy sentry and the EIP-3860
+						// initcode size limit halt REVM inside the instruction
+						// body before any in-body charge, leaving only the
+						// (zero) table static gas spent.
+						evm.zkGasTracker.Begin(evm.depth, byte(op), gasBefore)
+						if zkErr := evm.zkGasTracker.FinishAndCharge(evm.depth, zkGasPreExecutionGasAfter(op, gasBefore)); zkErr != nil {
 							evm.setZkGasErr()
 							return nil, ErrZkGasLimitExceeded
 						}

--- a/core/vm/operations_acl.go
+++ b/core/vm/operations_acl.go
@@ -17,8 +17,6 @@
 package vm
 
 import (
-	"errors"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/tracing"
@@ -33,7 +31,8 @@ func makeGasSStoreFunc(clearingRefund uint64) gasFunc {
 		}
 		// If we fail the minimum gas availability invariant, fail (0)
 		if contract.Gas <= params.SstoreSentryGasEIP2200 {
-			return 0, errors.New("not enough gas for reentrancy sentry")
+			// CHANGE(taiko): sentinel error so zk-gas metering recognizes the class.
+			return 0, errSStoreSentry
 		}
 		// Gas sentry honoured, do the actual gas calculation based on the stored value
 		var (

--- a/core/vm/taiko_zk_gas_runtime.go
+++ b/core/vm/taiko_zk_gas_runtime.go
@@ -520,7 +520,9 @@ func zkGasCreateBodyGasAfter(evm *EVM, stack *Stack, mem *Memory, gasBefore uint
 	}
 	var initcodeCost uint64
 	if evm.chainRules.IsShanghai {
-		if size > params.MaxInitCodeSize {
+		// Track the fork-aware EIP-3860 limit the dynamic gas functions
+		// enforce, so this reconstruction can never drift from them.
+		if CheckMaxInitCodeSize(&evm.chainRules, size) != nil {
 			return gasBefore, false
 		}
 		initcodeCost = toWordSize(size) * params.InitCodeWordGas

--- a/core/vm/taiko_zk_gas_runtime_test.go
+++ b/core/vm/taiko_zk_gas_runtime_test.go
@@ -2253,3 +2253,99 @@ func TestUnzenZkGas_LogTopicUnderflowInStaticContextChargesStaticGas(t *testing.
 		t.Fatalf("TxZkGasUsed = %d, want 375 for a static-context LOG1 topic underflow", got)
 	}
 }
+
+// TestUnzenZkGas_DynamicShortfallSpendsAllMirrorsReference pins the spend-all
+// reconstruction for dynamic-gas shortfalls outside the specially mirrored
+// families. The reference charges these trailing in-body costs (exponent
+// bytes, cold-access surcharges) with spend-all semantics after its table
+// static gas, which equals go-ethereum's full remaining frame gas at the step.
+func TestUnzenZkGas_DynamicShortfallSpendsAllMirrorsReference(t *testing.T) {
+	innerAddr := common.HexToAddress("0x2000000000000000000000000000000000000000")
+	coldAddr := common.HexToAddress("0x00000000000000000000000000000000deadbeef")
+
+	// PUSH32 all-ones exponent, PUSH1 2 base: the 32-byte exponent cost (1600)
+	// exceeds the child's remaining gas after the pushes.
+	expInner := []byte{byte(PUSH32)}
+	for range 32 {
+		expInner = append(expInner, 0xff)
+	}
+	expInner = append(expInner, byte(PUSH1), 0x02, byte(EXP), byte(STOP))
+
+	for _, tt := range []struct {
+		name     string
+		op       OpCode
+		inner    []byte
+		childGas uint16
+		want     uint64
+	}{
+		{
+			name:     "exp exponent bytes unaffordable",
+			op:       EXP,
+			inner:    expInner,
+			childGas: 100,
+			want:     94, // remaining gas at the EXP step, spent in full
+		},
+		{
+			name:     "cold sload unaffordable",
+			op:       SLOAD,
+			inner:    []byte{byte(PUSH1), 0x00, byte(SLOAD), byte(STOP)},
+			childGas: 150,
+			want:     147, // remaining gas at the SLOAD step, spent in full
+		},
+		{
+			name:     "cold balance unaffordable",
+			op:       BALANCE,
+			inner:    append(append([]byte{byte(PUSH20)}, coldAddr.Bytes()...), byte(BALANCE), byte(STOP)),
+			childGas: 150,
+			want:     147, // remaining gas at the BALANCE step, spent in full
+		},
+		{
+			name:     "cold extcodesize unaffordable",
+			op:       EXTCODESIZE,
+			inner:    append(append([]byte{byte(PUSH20)}, coldAddr.Bytes()...), byte(EXTCODESIZE), byte(STOP)),
+			childGas: 150,
+			want:     147, // remaining gas at the EXTCODESIZE step, spent in full
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			meter, evm := newOpcodeMirrorEVM(t, spawnBoundaryCallCodeWithGas(CALL, innerAddr, tt.childGas), map[common.Address][]byte{
+				innerAddr: tt.inner,
+			}, tt.op)
+
+			_, _, err := evm.Call(common.Address{}, spawnBoundaryOuterAddr, nil, 200_000, new(uint256.Int))
+			if err != nil {
+				t.Fatalf("Call returned error: %v", err)
+			}
+			if got := meter.TxZkGasUsed(); got != tt.want {
+				t.Fatalf("TxZkGasUsed = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestUnzenZkGas_CreateOversizedInitcodeChargesNothingOnDynamicRoute pins the
+// EIP-3860 size-limit failure on the dynamic-gas route (the 32000 base cost is
+// affordable, so the shortfall surfaces from the dynamic gas function): the
+// reference halts gas-preserving before any in-body charge and CREATE-family
+// table static gas is zero, so nothing may be metered.
+func TestUnzenZkGas_CreateOversizedInitcodeChargesNothingOnDynamicRoute(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		code []byte
+	}{
+		{"create", common.Hex2Bytes("61c00160006000f000")},
+		{"create2", common.Hex2Bytes("600061c00160006000f500")},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			meter, evm := newCreateShortfallEVM(t, tt.code, nil)
+
+			_, _, err := evm.Call(common.Address{}, spawnBoundaryOuterAddr, nil, 100_000, new(uint256.Int))
+			if !errors.Is(err, ErrOutOfGas) {
+				t.Fatalf("Call err = %v, want %v", err, ErrOutOfGas)
+			}
+			if got := meter.TxZkGasUsed(); got != 0 {
+				t.Fatalf("TxZkGasUsed = %d, want 0 for an oversized-initcode dynamic failure", got)
+			}
+		})
+	}
+}

--- a/miner/taiko_worker.go
+++ b/miner/taiko_worker.go
@@ -317,7 +317,14 @@ func (w *Miner) sealBlockWith(
 
 		// CHANGE(taiko): commit transaction zk gas on success.
 		if zkGasMeter != nil {
-			if commitErr := zkGasMeter.CommitTransaction(); commitErr != nil && i > 0 {
+			if commitErr := zkGasMeter.CommitTransaction(); commitErr != nil {
+				// The anchor can never be truncated: fail sealing instead of
+				// building a block the reference implementation rejects.
+				// Unreachable in practice, since charging already bounds
+				// committed+in-flight zk gas to the block limit.
+				if i == 0 {
+					return nil, fmt.Errorf("anchor transaction failed: %w", commitErr)
+				}
 				zkGasMeter.ResetTransaction()
 				break
 			}


### PR DESCRIPTION
## Summary

Follow-up to the #586–#593 zk-gas alignment series. A full three-agent re-audit of tip 77793e247 against alethia-reth `main` (ab87808, revm-interpreter 35.0.1) found **no remaining divergent window** — but it flagged a handful of couplings that are aligned only by coincidence, plus latent state-transition asymmetries that would silently fork if either side refactors or if code ever appears at a system address. This PR eliminates those so the alignment is structural rather than accidental. **No consensus-visible value changes on any reachable path** — every zk metered amount and state transition is byte-identical before and after; the red/green cases below are all currently-unobservable (empty system addresses) or provably unreachable.

## Changes

**Metering robustness (values unchanged, verified by pins):**
- `core/vm/errors.go`, `operations_acl.go`, `gas_table.go`: the SSTORE reentrancy-sentry failure becomes a sentinel (`errSStoreSentry`). Previously it matched none of the interpreter's zk hooks and metered 0 *by omission*; the reference also yields 0, but only because its sentry halt is gas-preserving and SSTORE's table static is 0 — two moving parts on each side with nothing pinning them together.
- `core/vm/interpreter.go`: explicit dynamic-gas-error branch for `errSStoreSentry` and `ErrMaxInitCodeSizeExceeded` → meter the table static (0 for SSTORE/CREATE/CREATE2) via `zkGasPreExecutionGasAfter`, mirroring the reference's body order (both checks halt gas-preserving before any in-body charge, after the central static deduction).
- `core/vm/taiko_zk_gas_runtime.go`: `zkGasCreateBodyGasAfter` now tracks the fork-aware EIP-3860 limit via `CheckMaxInitCodeSize` instead of hardcoding `params.MaxInitCodeSize` (identical under Unzen→Osaka; can no longer drift from the dynamic gas functions if Unzen ever remaps).

**State-transition alignment (latent divergences closed):**
- `core/state_processor.go`: skip the EIP-7002/7251 request-queue system calls on Taiko chains. The reference block executor never runs post-execution request calls (`Requests::default()`); both clients pin `RequestsHash = EmptyRequestsHash`. geth ran them — and this is **third-party-triggerable**, not hypothetical: the canonical EIP-7002/7251 contracts deploy via keyless, chain-agnostic presigned transactions that anyone can replay on Taiko. After such a deployment, geth's queue calls return non-empty requests, `CalcRequestsHash` diverges from the pinned `EmptyRequestsHash`, and geth rejects every subsequent block while the reference keeps advancing. Gated at `processRequestsSystemCall` so import, upstream sealing, and test chain generation all behave identically.
- `core/state_processor.go`: system calls (EIP-4788 beacon root, EIP-2935 parent hash, request queues) observe the reference's gas limit on Taiko chains: `params.MaxTxGas` (16,777,216, the EIP-7825 cap alethia-reth applies to every system call via `MAX_SYSTEM_CALL_GAS_LIMIT`) instead of upstream's 30,000,000. Observable only by code installed at a system address.
- `core/state_processor.go`, `miner/taiko_worker.go`: a zk-gas commit failure on the **anchor** transaction now fails block processing/sealing instead of being silently ignored (`commitErr != nil && i > 0` skipped the anchor case entirely, appending the receipt without committing its zk gas). Unreachable in practice — charging already bounds committed+in-flight zk gas to the block limit, so the overflow-only `CommitTransaction` cannot fail — but the reference errors on any commit failure and the anchor can never be truncated. Non-anchor behavior (truncate) is unchanged.

**New regressions:**
- Spend-all dynamic-shortfall pins for the windows outside the specially-mirrored families: EXP exponent-byte cost, cold SLOAD/BALANCE/EXTCODESIZE (the reference charges these in-body with spend-all semantics after its table static — equals geth's full remaining frame gas at the step). These were source-verified aligned in the audit but had no test.
- Oversized-initcode **dynamic-route** pins for CREATE/CREATE2 (base cost affordable, EIP-3860 failure from the dynamic gas function → 0 metered).
- Red/green: request-queue skip (code at the queue addresses must not execute on Taiko; still executes upstream) and system-call gas limit (GAS-probe contract at the system addresses observes 16,777,214 on Taiko, 29,999,998 upstream).

## Audited and deliberately not changed

- Mainnet `UnzenTime = MaxUint64` vs the reference's `Never` — divergent only at timestamp 2^64−1; touching mainnet fork plumbing isn't worth that.
- Legacy-mode builder behavior when the *anchor* exceeds the zk limit (geth fails the build; the reference assembles an anchor-less block that both clients then reject on import) — outcome-aligned; the cleaner fix belongs on the reference side.
- EIP-6110 deposit-log parsing still runs under `postExecution` — provably inert (`DepositContractAddress` is unset, and address-zero can never emit logs).
- Residual system-call *environment* differences beyond the cap (the reference runs system calls as full inner transactions: intrinsic gas inside the cap, block-env gas limit/basefee swapped for the call, contract-only state retention) — unobservable by the canonical system contracts, which read none of these; noted in `systemCallGasLimit`'s doc comment and left for a follow-up if ever needed.

## Test Plan

- [x] `go test ./core/vm -count=1`
- [x] `go test ./core ./miner ./consensus/taiko -count=1`
- [x] `go test ./eth/tracers/... -count=1`
- [x] New core tests red before / green after; new vm pins derive their expected values from the reference charge order
- [x] `gofmt -s -l` clean on touched files, `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
