### PR TITLE
feat(taiko_genesis): schedule Mainnet Unzen fork

### DIFF
--- a/core/taiko_genesis.go
+++ b/core/taiko_genesis.go
@@ -28,7 +28,7 @@ var (
 
 	DevnetUnzenTime  uint64 = 0
 	MasayaUnzenTime  uint64 = 0
-	MainnetUnzenTime uint64 = math.MaxUint64
+	MainnetUnzenTime uint64 = 1_786_021_200 // 2026-08-06 13:00:00 UTC
 	HoodiUnzenTime   uint64 = 1_781_787_600
 )
 

--- a/core/taiko_genesis_test.go
+++ b/core/taiko_genesis_test.go
@@ -1,7 +1,6 @@
 package core
 
 import (
-	"math"
 	"math/big"
 	"testing"
 
@@ -85,17 +84,65 @@ func TestTaikoGenesisBlock_HoodiActivatesUnzenAtScheduledTime(t *testing.T) {
 	t.Logf("Taiko Hoodi genesis hash: %s", genesis.ToBlock().Hash())
 }
 
+func TestTaikoGenesisBlock_MainnetActivatesUnzenAtScheduledTime(t *testing.T) {
+	genesis := TaikoGenesisBlock(params.TaikoMainnetNetworkID.Uint64())
+	cfg := genesis.Config
+	if cfg.ChainID.Cmp(params.TaikoMainnetNetworkID) != 0 {
+		t.Fatalf("ChainID = %v, want %v", cfg.ChainID, params.TaikoMainnetNetworkID)
+	}
+
+	const mainnetUnzenTime uint64 = 1_786_021_200 // 2026-08-06 13:00:00 UTC
+	if cfg.UnzenTime == nil {
+		t.Fatalf("UnzenTime is nil, want %d", mainnetUnzenTime)
+	}
+	if got := *cfg.UnzenTime; got != mainnetUnzenTime {
+		t.Fatalf("UnzenTime = %d, want %d", got, mainnetUnzenTime)
+	}
+
+	zeroBlock := big.NewInt(0)
+	before := mainnetUnzenTime - 1
+	if cfg.IsUnzen(before) {
+		t.Fatalf("Mainnet Unzen fork is active at timestamp %d", before)
+	}
+	if !cfg.IsUnzen(mainnetUnzenTime) {
+		t.Fatalf("Mainnet Unzen fork is not active at timestamp %d", mainnetUnzenTime)
+	}
+	if cfg.IsCancun(zeroBlock, before) {
+		t.Fatalf("Mainnet Cancun fork is active at timestamp %d", before)
+	}
+	if !cfg.IsCancun(zeroBlock, mainnetUnzenTime) {
+		t.Fatalf("Mainnet Cancun fork is not active at timestamp %d", mainnetUnzenTime)
+	}
+	if cfg.IsPrague(zeroBlock, before) {
+		t.Fatalf("Mainnet Prague fork is active at timestamp %d", before)
+	}
+	if !cfg.IsPrague(zeroBlock, mainnetUnzenTime) {
+		t.Fatalf("Mainnet Prague fork is not active at timestamp %d", mainnetUnzenTime)
+	}
+	if cfg.IsOsaka(zeroBlock, before) {
+		t.Fatalf("Mainnet Osaka fork is active at timestamp %d", before)
+	}
+	if !cfg.IsOsaka(zeroBlock, mainnetUnzenTime) {
+		t.Fatalf("Mainnet Osaka fork is not active at timestamp %d", mainnetUnzenTime)
+	}
+}
+
 func TestTaikoGenesisBlock_MasayaDoesNotContaminateMainnetForkTimes(t *testing.T) {
 	TaikoGenesisBlock(params.MasayaDevnetNetworkID.Uint64())
 
 	genesis := TaikoGenesisBlock(params.TaikoMainnetNetworkID.Uint64())
 	cfg := genesis.Config
+
+	const mainnetUnzenTime uint64 = 1_786_021_200 // 2026-08-06 13:00:00 UTC
 	if cfg.UnzenTime == nil {
-		t.Fatal("UnzenTime is nil, want MaxUint64")
+		t.Fatalf("UnzenTime is nil, want %d", mainnetUnzenTime)
 	}
-	if got := *cfg.UnzenTime; got != math.MaxUint64 {
-		t.Fatalf("UnzenTime = %d, want %d", got, uint64(math.MaxUint64))
+	if got := *cfg.UnzenTime; got != mainnetUnzenTime {
+		t.Fatalf("UnzenTime = %d, want %d", got, mainnetUnzenTime)
 	}
+	// Masaya activates Cancun/Prague/Osaka at genesis; constructing it must not
+	// leak those timestamps into the Mainnet config, which stays inactive until
+	// the scheduled Unzen time.
 	zeroBlock := big.NewInt(0)
 	if cfg.IsCancun(zeroBlock, 0) {
 		t.Fatal("Mainnet Cancun fork is active at genesis after constructing Masaya")


### PR DESCRIPTION
## Summary

Schedules the Taiko **Mainnet Unzen** fork.

| | Value |
|---|---|
| Fork time | `1786021200` |
| UTC | **2026-08-06 13:00:00 UTC** |
| Previously | `math.MaxUint64` (unscheduled) |

Activating Unzen also pulls the `Cancun`, `Prague`, and `Osaka` timestamps to the same time (the block-time forks become active at the Unzen boundary), matching the Hoodi scheduling in #571.

## Changes

- `core/taiko_genesis.go` — set `MainnetUnzenTime` to `1_786_021_200`.
- `core/taiko_genesis_test.go` — replace the "Mainnet Unzen is unscheduled (`MaxUint64`)" assertion with a positive `TestTaikoGenesisBlock_MainnetActivatesUnzenAtScheduledTime` (mirrors the Hoodi test), and update the Masaya-contamination test to expect the scheduled time while still verifying no fork is active at genesis.

## Testing

- `go test ./core/ -run TestTaikoGenesisBlock` — all pass
- `go test ./params/ ./consensus/taiko/` — pass
- `gofmt` / `go vet` clean

> Draft: pending confirmation of the exact activation timestamp before marking ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
